### PR TITLE
provisioner: keywriter: Move logs to serial-priority directory structure

### DIFF
--- a/device-provisioner/rpi-sb-provisioner.service
+++ b/device-provisioner/rpi-sb-provisioner.service
@@ -5,4 +5,4 @@ Description=Transform and flash a supplied operating system to a Secure Boot Ras
 Type=oneshot
 ExecStart=/usr/local/bin/provisioner.sh %I
 EnvironmentFile=/etc/rpi-sb-provisioner/config
-StandardOutput=file:/var/log/rpi-sb-provisioner/provisioner/%I.log
+StandardOutput=file:/var/log/rpi-sb-provisioner/%I/provisioner.log

--- a/device-triage/triage.sh
+++ b/device-triage/triage.sh
@@ -35,8 +35,8 @@ if [ -e "${DEVICE_SERIAL_STORE}/${TARGET_DEVICE_SERIAL}" ]; then
     echo "If this is in error, delete ${DEVICE_SERIAL_STORE}/${TARGET_DEVICE_SERIAL}"
 
     # Start the boot provisioner service
-    mkdir -p /var/log/rpi-sb-provisioner/provisioner/
-    touch "/var/log/rpi-sb-provisioner/provisioner/${TARGET_DEVICE_SERIAL}.log"
+    mkdir -p /var/log/rpi-sb-provisioner/"${TARGET_DEVICE_SERIAL}"/
+    touch "/var/log/rpi-sb-provisioner/${TARGET_DEVICE_SERIAL}/provisioner.log"
     systemctl start rpi-sb-provisioner@"${TARGET_DEVICE_SERIAL}"
 
     exit 0
@@ -45,8 +45,8 @@ else
     echo "Using keyfile at ${CUSTOMER_KEY_FILE_PEM}"
 
     # Start the keywriter service
-    mkdir -p /var/log/rpi-sb-provisioner/keywriter/
-    touch "/var/log/rpi-sb-provisioner/keywriter/${TARGET_DEVICE_SERIAL}.log"
+    mkdir -p /var/log/rpi-sb-provisioner/"${TARGET_DEVICE_SERIAL}"/
+    touch "/var/log/rpi-sb-provisioner/${TARGET_DEVICE_SERIAL}/keywriter.log"
     systemctl start rpi-sb-keywriter@"${TARGET_DEVICE_SERIAL}"
     exit 0
 fi

--- a/key-writer/rpi-sb-keywriter.service
+++ b/key-writer/rpi-sb-keywriter.service
@@ -5,4 +5,4 @@ Description=Provision signing keys to a Raspberry Pi Device
 Type=oneshot
 ExecStart=/usr/local/bin/keywriter.sh %I
 EnvironmentFile=/etc/rpi-sb-provisioner/config
-StandardOutput=file:/var/log/rpi-sb-provisioner/keywriter/%I.log
+StandardOutput=file:/var/log/rpi-sb-provisioner/%I/keywriter.log


### PR DESCRIPTION
#7 was made in error, we _should_ be using serial-priority for the logging structure, rather than stage-priority.