### PR TITLE
HSM: Fixup string passing of signing directives

### DIFF
--- a/device-provisioner/provisioner.sh
+++ b/device-provisioner/provisioner.sh
@@ -213,7 +213,8 @@ cp "$(get_fastboot_config_file)" "${RPI_SB_WORKDIR}"/config.txt
 sha256sum "${RPI_SB_WORKDIR}"/boot.img | awk '{print $1}' > "${RPI_SB_WORKDIR}"/boot.sig
 echo -n "rsa2048: " >> "${RPI_SB_WORKDIR}"/boot.sig
 # Prefer PKCS11 over PEM keyfiles, if both are specified.
-${OPENSSL} dgst -sign "$(get_signing_directives)" -sha256 "${RPI_SB_WORKDIR}"/boot.img | xxd -c 4096 -p >> "${RPI_SB_WORKDIR}"/boot.sig
+# shellcheck disable=SC2046
+${OPENSSL} dgst -sign $(get_signing_directives) -sha256 "${RPI_SB_WORKDIR}"/boot.img | xxd -c 4096 -p >> "${RPI_SB_WORKDIR}"/boot.sig
 
 announce_stop "Finding/generating fastboot image"
 
@@ -379,7 +380,8 @@ if [[ -z $(check_file_is_expected "${RPI_SB_WORKDIR}"/bootfs-temporary.img "img"
     # N.B. rpi-eeprom-digest could be used here but it includes a timestamp that is not required for this use-case
     sha256sum "${TMP_DIR}"/boot.img | awk '{print $1}' > "${TMP_DIR}"/boot.sig
     echo -n "rsa2048: " >> "${TMP_DIR}"/boot.sig
-    ${OPENSSL} dgst -sign "$(get_signing_directives)" -sha256 "${TMP_DIR}"/boot.img | xxd -c 4096 -p >> "${TMP_DIR}"/boot.sig
+    # shellcheck disable=SC2046
+    ${OPENSSL} dgst -sign $(get_signing_directives) -sha256 "${TMP_DIR}"/boot.img | xxd -c 4096 -p >> "${TMP_DIR}"/boot.sig
     announce_stop "boot.img signing"
 
     announce_start "Boot Image partition extraction"

--- a/key-writer/keywriter.sh
+++ b/key-writer/keywriter.sh
@@ -32,7 +32,8 @@ writeSig() {
    echo "ts: $(date -u +%s)" >> "${OUTPUT}"
 
    if [ -n "$(get_signing_directives)" ]; then
-      "${OPENSSL}" dgst -sign "$(get_signing_directives)" -sha256 -out "${SIG_TMP}" "${IMAGE}"
+      # shellcheck disable=SC2046
+      "${OPENSSL}" dgst -sign $(get_signing_directives) -sha256 -out "${SIG_TMP}" "${IMAGE}"
       echo "rsa2048: $(xxd -c 4096 -p < "${SIG_TMP}")" >> "${OUTPUT}"
    fi
    rm "${SIG_TMP}"


### PR DESCRIPTION
We pass the return value of get_signing_directives as a string - but then double-quote this in the invocation, mixing arguments as one.

This, rightly, causes OpenSSL to complain.

So, let's drop the erroneous double-quotes, and include a line to silence shellcheck in the various sites where we use the result as an argument.