### PR TITLE
debian/install: Install known-good recovery.bin

### DIFF
--- a/debian/install
+++ b/debian/install
@@ -22,6 +22,7 @@ host-support/fastboot-gadget.img /var/lib/rpi-sb-provisioner
 host-support/make-boot-image /usr/local/bin
 host-support/rpi-sb-provisioner /etc/default/
 host-support/bootloader.config /var/lib/rpi-sb-provisioner/
+host-support/recovery.bin /var/lib/rpi-sb-provisioner
 
 device-provisioner/provisioner.sh /usr/local/bin
 device-provisioner/rpi-sb-provisioner@.service /usr/local/lib/systemd/system


### PR DESCRIPTION
Changing the packaging system meant we missed the recovery.bin packaging - not caught in the test system because the file was manually moved into place, and apt didn't remove it on a delete.

Fixes #36