### PR TITLE
Fixup monitor status watching

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: rpi-sb-provisioner
 Section: admin
 Priority: optional
 Maintainer: Tom Dewey <tom.dewey@raspberrypi.com>
-Build-Depends: debhelper (>= 11), python3, dh-virtualenv (>= 0.8)
+Build-Depends: debhelper (>= 11), python3, python3-virtualenv, dh-virtualenv (>= 0.8)
 Standards-Version: 1.0.2
 homepage: https://www.raspberrypi.com/software
 

--- a/monitor/systemctl_python.py
+++ b/monitor/systemctl_python.py
@@ -51,14 +51,10 @@ def list_completed_devices():
     all_devices = list_seen_devices()
     completed_devices = []
     for device in all_devices:
-        provisioner_success = -1
         if path.exists("/var/log/rpi-sb-provisioner/" + device + "/progress"):
             f = open("/var/log/rpi-sb-provisioner/" + device + "/progress", "r")
             status = f.read()
-            if "PROVISIONER-EXITED" in status:
-                if "PROVISIONER-FINISHED" in status: provisioner_success = 1
-                else: provisioner_success = 0
-            if provisioner_success == 1:
+            if "PROVISIONER-FINISHED" in status:
                 modified_time = stat("/var/log/rpi-sb-provisioner/" + device + "/progress").st_mtime_ns
                 completed_devices.append((device, modified_time))
             f.close()
@@ -68,15 +64,10 @@ def list_failed_devices():
     all_devices = list_seen_devices()
     failed_devices = []
     for device in all_devices:
-        provisioner_success = -1
-        keywriter_success = -1
         if path.exists("/var/log/rpi-sb-provisioner/" + device + "/progress"):
             f = open("/var/log/rpi-sb-provisioner/" + device + "/progress", "r")
             status = f.read()
-            if "PROVISIONER-EXITED" in status:
-                if "PROVISIONER-FINISHED" in status: provisioner_success = 1
-                else: provisioner_success = 0
-            if provisioner_success == 0 or keywriter_success == 0:
+            if "PROVISIONER-ABORTED" in status:
                 modified_time = stat("/var/log/rpi-sb-provisioner/" + device + "/progress").st_mtime_ns
                 failed_devices.append((device, modified_time))
             f.close()


### PR DESCRIPTION
For the completed and failed lists, watch for the appropriate status flags and add the device directly.