### PR TITLE
Improve observability

### DIFF
--- a/monitor/systemctl_python.py
+++ b/monitor/systemctl_python.py
@@ -26,7 +26,10 @@ def list_working_units(service_name):
         if "rpi-sb-" in line:
             if not("failed" in line):
                 name=line[line.find("rpi-sb-"):line.find(".service")]
-                units.append(name)
+                if "triage" in name:
+                    units.append(name.replace("rpi-sb-triage@", ""))
+                if "provisioner" in name:
+                    units.append(name.replace("rpi-sb-provisioner@", ""))
     return units
 
 def list_failed_units(service_name):

--- a/monitor/systemctl_python.py
+++ b/monitor/systemctl_python.py
@@ -51,14 +51,10 @@ def list_completed_devices():
     all_devices = list_seen_devices()
     completed_devices = []
     for device in all_devices:
-        provisioner_success = -1
         if path.exists("/var/log/rpi-sb-provisioner/" + device + "/progress"):
             f = open("/var/log/rpi-sb-provisioner/" + device + "/progress", "r")
             status = f.read()
-            if "PROVISIONER-EXITED" in status:
-                if "PROVISIONER-FINISHED" in status: provisioner_success = 1
-                else: provisioner_success = 0
-            if provisioner_success == 1:
+            if "PROVISIONER-FINISHED" in status:
                 modified_time = stat("/var/log/rpi-sb-provisioner/" + device + "/progress").st_mtime_ns
                 completed_devices.append((device, modified_time))
             f.close()
@@ -68,15 +64,10 @@ def list_failed_devices():
     all_devices = list_seen_devices()
     failed_devices = []
     for device in all_devices:
-        provisioner_success = -1
-        keywriter_success = -1
         if path.exists("/var/log/rpi-sb-provisioner/" + device + "/progress"):
             f = open("/var/log/rpi-sb-provisioner/" + device + "/progress", "r")
             status = f.read()
-            if "PROVISIONER-EXITED" in status:
-                if "PROVISIONER-FINISHED" in status: provisioner_success = 1
-                else: provisioner_success = 0
-            if provisioner_success == 0 or keywriter_success == 0:
+            if "PROVISIONER-ABORTED" in status:
                 modified_time = stat("/var/log/rpi-sb-provisioner/" + device + "/progress").st_mtime_ns
                 failed_devices.append((device, modified_time))
             f.close()

--- a/service/rpi-sb-provisioner.sh
+++ b/service/rpi-sb-provisioner.sh
@@ -288,7 +288,17 @@ fi
 
 # With the EEPROMs configured and signed, RPIBoot them.
 mkdir -p "/var/log/rpi-sb-provisioner/${TARGET_DEVICE_SERIAL}/metadata/"
-[ -z "${DEMO_MODE_ONLY}" ] && rpiboot -d "${FLASHING_DIR}" -i "${TARGET_DEVICE_SERIAL}" -j "/var/log/rpi-sb-provisioner/${TARGET_DEVICE_SERIAL}/metadata/"
+keywriter_log "Writing key and EEPROM configuration to the device"
+[ -z "${DEMO_MODE_ONLY}" ] && timeout 120 rpiboot -d "${FLASHING_DIR}" -i "${TARGET_DEVICE_SERIAL}" -j "/var/log/rpi-sb-provisioner/${TARGET_DEVICE_SERIAL}/metadata/"
+KEYWRITER_EXIT_STATUS=$?
+if [ $KEYWRITER_EXIT_STATUS -eq 124 ]
+then
+keywriter_log "Writing failed, timed out."
+echo "${KEYWRITER_ABORTED}" >> /var/log/rpi-sb-provisioner/"${TARGET_DEVICE_SERIAL}"/progress
+return 124
+else
+keywriter_log "Writing completed."
+fi
 
 rm -rf "${FLASHING_DIR}"
 

--- a/service/rpi-sb-provisioner.sh
+++ b/service/rpi-sb-provisioner.sh
@@ -603,14 +603,14 @@ announce_stop "Starting fastboot"
 
 announce_start "Selecting and interrogating device"
 
-announce_start "Getting target information"
+#announce_start "Getting target information"
 #TARGET_STORAGE_LIST_RESULT="$(get_variable storage-types-list)"
 #TARGET_PI_GENERATION="$(get_variable hw-generation)"
 #TARGET_DUID="$(get_variable device-uuid)"
 #TARGET_SERIAL="$(get_variable serialno)"
-announce_stop "Getting target information"
+#announce_stop "Getting target information"
 
-announce_start "Storage device check"
+#announce_start "Storage device check"
 #STORAGE_FOUND=0
 #for device in ${TARGET_STORAGE_LIST_RESULT}
 #do
@@ -623,7 +623,7 @@ announce_start "Storage device check"
 #    die "Selected storage type is not available, wanted one of [${TARGET_STORAGE_LIST_RESULT}], got ${RPI_DEVICE_STORAGE_TYPE}"
 #fi
 
-announce_stop "Storage device check"
+#announce_stop "Storage device check"
 
 #announce_start "Raspberry Pi Generation check"
 #if ${RPI_DEVICE_FAMILY} != ${TARGET_PI_GENERATION}; then

--- a/service/rpi-sb-provisioner.sh
+++ b/service/rpi-sb-provisioner.sh
@@ -589,7 +589,16 @@ ${OPENSSL} dgst -sign $(get_signing_directives) -sha256 "${RPI_SB_WORKDIR}"/boot
 announce_stop "Finding/generating fastboot image"
 
 announce_start "Starting fastboot"
-[ -z "${DEMO_MODE_ONLY}" ] && rpiboot -v -d "${RPI_SB_WORKDIR}" -i "${TARGET_DEVICE_SERIAL}"
+[ -z "${DEMO_MODE_ONLY}" ] && timeout 120 rpiboot -v -d "${RPI_SB_WORKDIR}" -i "${TARGET_DEVICE_SERIAL}"
+FLASHING_GADGET_EXIT_STATUS=$?
+if [ $FLASHING_GADGET_EXIT_STATUS -eq 124 ]
+then
+provisioner_log "Loading Fastboot failed, timed out."
+echo "${PROVISIONER_ABORTED}" >> /var/log/rpi-sb-provisioner/"${TARGET_DEVICE_SERIAL}"/progress
+return 124
+else
+provisioner_log "Fastboot loaded."
+fi
 announce_stop "Starting fastboot"
 
 announce_start "Selecting and interrogating device"

--- a/service/rpi-sb-provisioner.sh
+++ b/service/rpi-sb-provisioner.sh
@@ -804,6 +804,17 @@ fi # Slow path
 announce_start "Erase / Partition Device Storage"
 
 # Arbitrary sleeps to handle lack of correct synchronisation in fastbootd.
+[ -z "${DEMO_MODE_ONLY}" ] && timeout 30 fastboot getvar version
+FASTBOOT_EXIT_STATUS=$?
+if [ $FASTBOOT_EXIT_STATUS -eq 124 ]
+then
+provisioner_log "Loading Fastboot failed, timed out."
+echo "${PROVISIONER_ABORTED}" >> /var/log/rpi-sb-provisioner/"${TARGET_DEVICE_SERIAL}"/progress
+return 124
+else
+provisioner_log "Fastboot loaded."
+fi
+
 [ -z "${DEMO_MODE_ONLY}" ] && fastboot erase "${RPI_DEVICE_STORAGE_TYPE}"
 sleep 2
 [ -z "${DEMO_MODE_ONLY}" ] && fastboot oem partinit "${RPI_DEVICE_STORAGE_TYPE}" DOS "${DISK_IDENTIFIER}"


### PR DESCRIPTION
This PR moves along two axes:

1) Improvements to the Monitor to make in-progress devices inspectable, and prune redundant information from the items
2) Introduction of timeout calls ahead of each call likely to block in a failure case. The timeouts are somewhat conservative, and will emit the signal of failure for the Monitor.