### PR TITLE
Monitor: Find completed devices correctly.

### DIFF
--- a/monitor/monitor.py
+++ b/monitor/monitor.py
@@ -37,12 +37,10 @@ class DevicesList(Widget):
         self.set_interval(1/20, self.update_devices)
 
 class CompletedDevicesList(Widget):
-    dev_type_g = ""
     devices=reactive(tuple[str, int])
     def compose(self) -> ComposeResult:
          yield DataTable()
-    def __init__(self, dev_type):
-        self.dev_type = dev_type
+    def __init__(self):
         super().__init__()
     def update_devices(self) -> None:
         self.devices = systemctl_python.list_completed_devices()
@@ -61,13 +59,11 @@ class CompletedDevicesList(Widget):
         table.add_rows(ROWS[1:])
         self.set_interval(1/20, self.update_devices)
 
-class Failed_devices_list(Static):
-    dev_type_g = ""
+class FailedDevicesList(Static):
     devices=reactive(tuple[str, int])
     def compose(self) -> ComposeResult:
          yield DataTable()
-    def __init__(self, dev_type):
-        self.dev_type = dev_type
+    def __init__(self):
         super().__init__()
     def update_devices(self) -> None:
         self.devices = systemctl_python.list_failed_devices()
@@ -97,11 +93,11 @@ class Provision_Box(Static):
 
 class Completed_Box(Static):
     def compose(self) -> ComposeResult:
-        yield ScrollableContainer(Static("Completed \n----------------"), CompletedDevicesList(dev_type="provision"))
+        yield ScrollableContainer(Static("Completed \n----------------"), CompletedDevicesList())
 
 class Failed_Box(Static):
     def compose(self) -> ComposeResult:
-        yield ScrollableContainer(Static("Failed \n----------------"), Failed_devices_list(dev_type="provision"))
+        yield ScrollableContainer(Static("Failed \n----------------"), FailedDevicesList())
 
 class Processing(Static):
     def compose(self) -> ComposeResult:

--- a/monitor/systemctl_python.py
+++ b/monitor/systemctl_python.py
@@ -76,9 +76,11 @@ def list_seen_devices():
         
     return units
 
-
+# Completed devices don't show up as systemd units, so we _must_ fall back to the log files
 def list_completed_devices():
-    all_devices = list_seen_devices()
+    all_devices = []
+    if os.path.exists("/var/log/rpi-sb-provisioner/"):
+        all_devices = os.listdir("/var/log/rpi-sb-provisioner")
     completed_devices = []
     for device in all_devices:
         if os.path.exists("/var/log/rpi-sb-provisioner/" + device + "/progress"):

--- a/service/rpi-sb-provisioner.sh
+++ b/service/rpi-sb-provisioner.sh
@@ -184,6 +184,7 @@ update_eeprom() {
         --out "${dst_image}" ${sign_args} \
         "${dst_image}.intermediate" || die "Failed to update EEPROM image"
     rm -f "${dst_image}.intermediate"
+    rm -f "${TMP_CONFIG_SIG}"
     set +x
 
 cat <<EOF


### PR DESCRIPTION
`systemd` doesn't give me a trivial way to find units that executed successfully and finished - but thankfully, we have log files for that.

So let's fall back to having monitor manually walk the log files, and perform some minor monitor clean-up while we're in there.

Fixes: #59 