### PR TITLE
service: Remove extraneous disk-id parameter

### DIFF
--- a/service/rpi-sb-provisioner.sh
+++ b/service/rpi-sb-provisioner.sh
@@ -826,7 +826,7 @@ set -e
 
 [ -z "${DEMO_MODE_ONLY}" ] && fastboot erase "${RPI_DEVICE_STORAGE_TYPE}"
 sleep 2
-[ -z "${DEMO_MODE_ONLY}" ] && fastboot oem partinit "${RPI_DEVICE_STORAGE_TYPE}" DOS "${DISK_IDENTIFIER}"
+[ -z "${DEMO_MODE_ONLY}" ] && fastboot oem partinit "${RPI_DEVICE_STORAGE_TYPE}" DOS
 sleep 2
 [ -z "${DEMO_MODE_ONLY}" ] && fastboot oem partapp "${RPI_DEVICE_STORAGE_TYPE}" 0c "$(stat -c%s "${RPI_SB_WORKDIR}"/bootfs-temporary.img)"
 sleep 2


### PR DESCRIPTION
This isn't set inside provisioner at all - but can be included in customer deployments and falsely be expanded into this command.

Remove reference to the disk id.