### PR TITLE
Pre-boot Authentication: Use the specified RPI_DEVICE_STORAGE_TYPE

### DIFF
--- a/service/rpi-sb-provisioner.sh
+++ b/service/rpi-sb-provisioner.sh
@@ -848,6 +848,9 @@ if [ ! -e "${RPI_SB_WORKDIR}/bootfs-temporary.img" ] ||
             depmod --basedir "${initramfs_dir}" "${kernel}"
         done
 
+        # Configure the cryptroot script to use the correct storage device
+        sed -i "s/mmcblk0/${RPI_DEVICE_STORAGE_TYPE}/g" "${initramfs_dir}usr/bin/init_cryptroot.sh"
+
         find . -print0 | cpio --null -ov --format=newc > ../initramfs.cpio
         cd "${TMP_DIR}"
         rm -rf "${TMP_DIR}"/initramfs


### PR DESCRIPTION
The Cryptroot package from pi-gen-micro assumes your storage device is called mmcblk0 - and has no real way to know what your actual device is ahead of time.

In order to ensure that package is a works-by-default package, we make the change as part of our initramfs handling in rpi-sb-provisioner.

h/t @oliora

Fixes #123 