### PR TITLE
Add date and time prefix into logging

### DIFF
--- a/device-triage/triage.sh
+++ b/device-triage/triage.sh
@@ -16,38 +16,43 @@ read_config() {
 
 read_config
 
+datetime() {
+    date "+%Y-%m-%d %H:%M:%S"
+}
+
 TARGET_DEVICE_SERIAL="$(udevadm info --name="$1" --query=property --property=ID_SERIAL_SHORT --value)"
 mkdir -p /var/log/rpi-sb-provisioner/"${TARGET_DEVICE_SERIAL}"/
 touch /var/log/rpi-sb-provisioner/"${TARGET_DEVICE_SERIAL}"/triage.log
-echo "Starting triage for $1, serial: $TARGET_DEVICE_SERIAL" >> /var/log/rpi-sb-provisioner/"${TARGET_DEVICE_SERIAL}"/triage.log
+echo "$(datetime) Starting triage for $1, serial: $TARGET_DEVICE_SERIAL" >> /var/log/rpi-sb-provisioner/"${TARGET_DEVICE_SERIAL}"/triage.log
 
 if [ -z "${RPI_DEVICE_BOOTLOADER_CONFIG_FILE}" ]; then
     RPI_DEVICE_BOOTLOADER_CONFIG_FILE=/var/lib/rpi-sb-provisioner/bootloader.default
 fi
 
 if [ -z "${CUSTOMER_KEY_FILE_PEM}" ] && [ -z "${CUSTOMER_KEY_PKCS11_NAME}" ]; then
-    echo "You must provide a key in the environment via CUSTOMER_KEY_FILE_PEM, or a key name via CUSTOMER_KEY_PKCS11_NAME" >> /var/log/rpi-sb-provisioner/"${TARGET_DEVICE_SERIAL}"/triage.log
+    echo "$(datetime) You must provide a key in the environment via CUSTOMER_KEY_FILE_PEM, or a key name via CUSTOMER_KEY_PKCS11_NAME" >> /var/log/rpi-sb-provisioner/"${TARGET_DEVICE_SERIAL}"/triage.log
     exit 1
 fi
 
 if [ -z "${TARGET_DEVICE_SERIAL}" ]; then
-    echo "You must provide a device serial as the argument to this program" >> /var/log/rpi-sb-provisioner/"${TARGET_DEVICE_SERIAL}"/triage.log
+    echo "$(datetime) You must provide a device serial as the argument to this program" >> /var/log/rpi-sb-provisioner/"${TARGET_DEVICE_SERIAL}"/triage.log
     exit 1
 fi
 
+log_datetime=$(datetime)
 if [ -e "/var/log/rpi-sb-provisioner/${TARGET_DEVICE_SERIAL}/progress" ]; then
     # Status messages are more for human consumption than anything else.
     last_status=$(tail -n 1 "/var/log/rpi-sb-provisioner/${TARGET_DEVICE_SERIAL}/progress")
     {
-        echo "Observed provisioning state for ${TARGET_DEVICE_SERIAL}: ${last_status}"
-        echo "Not starting additional services, device already undergoing provisioning"
+        echo "${log_datetime} Observed provisioning state for ${TARGET_DEVICE_SERIAL}: ${last_status}"
+        echo "${log_datetime} Not starting additional services, device already undergoing provisioning"
     } >> /var/log/rpi-sb-provisioner/"${TARGET_DEVICE_SERIAL}"/triage.log
     echo "${TRIAGE_STARTED}" >> /var/log/rpi-sb-provisioner/"${TARGET_DEVICE_SERIAL}"/progress
 else
-    { 
-        echo "Device is completely new to us, starting keywriter"
-        echo "Using keyfile at ${CUSTOMER_KEY_FILE_PEM}"
-        echo "Using OS image at ${GOLD_MASTER_OS_FILE}"
+    {
+        echo "${log_datetime} Device is completely new to us, starting keywriter"
+        echo "${log_datetime} Using keyfile at ${CUSTOMER_KEY_FILE_PEM}"
+        echo "${log_datetime} Using OS image at ${GOLD_MASTER_OS_FILE}"
     } >> /var/log/rpi-sb-provisioner/"${TARGET_DEVICE_SERIAL}"/triage.log
 
     # Start the keywriter service

--- a/service/rpi-sb-provisioner.sh
+++ b/service/rpi-sb-provisioner.sh
@@ -15,6 +15,9 @@ export PROVISIONER_FINISHED="PROVISIONER-FINISHED"
 export PROVISIONER_ABORTED="PROVISIONER-ABORTED"
 export PROVISIONER_STARTED="PROVISIONER-STARTED"
 
+datetime() {
+    date "+%Y-%m-%d %H:%M:%S"
+}
 
 ring_bell() {
     tput bel
@@ -81,11 +84,11 @@ simg_expanded_size() {
 }
 
 keywriter_log() {
-    echo "$@" >> /var/log/rpi-sb-provisioner/"${TARGET_DEVICE_SERIAL}"/keywriter.log
+    echo "$(datetime) $@" >> /var/log/rpi-sb-provisioner/"${TARGET_DEVICE_SERIAL}"/keywriter.log
 }
 
 provisioner_log() {
-    echo "$@" >> /var/log/rpi-sb-provisioner/"${TARGET_DEVICE_SERIAL}"/provisioner.log
+    echo "$(datetime) $@" >> /var/log/rpi-sb-provisioner/"${TARGET_DEVICE_SERIAL}"/provisioner.log
 }
 
 
@@ -173,7 +176,7 @@ identifyBootloaderConfig() {
 update_eeprom() {
     src_image="$1"
     dst_image="$2"
-    pem_file="$3" 
+    pem_file="$3"
     public_pem_file="$4"
     sign_args=""
 
@@ -744,7 +747,7 @@ if [ ! -e "${RPI_SB_WORKDIR}/bootfs-temporary.img" ] ||
     announce_start "OS Image Copying (potentially slow)"
     cp "${GOLD_MASTER_OS_FILE}" "${COPY_OS_COMBINED_FILE}"
     announce_stop "OS Image Copying (potentially slow)"
-    # Mount the 'complete' image as a series of partitions 
+    # Mount the 'complete' image as a series of partitions
     cnt=0
     until ensure_next_loopdev && LOOP_DEV="$(losetup --show --find --partscan "${COPY_OS_COMBINED_FILE}")"; do
         if [ $cnt -lt 5 ]; then
@@ -798,7 +801,7 @@ if [ ! -e "${RPI_SB_WORKDIR}/bootfs-temporary.img" ] ||
         zstd --rm -f -d "${initramfs_compressed_file}" -o "${TMP_DIR}"/initramfs.cpio ${DEBUG}
         # shellcheck disable=SC2155
         rootfs_mount=$(realpath "${TMP_DIR}"/rpi-rootfs-img-mount)
-        cd "${TMP_DIR}"/initramfs 
+        cd "${TMP_DIR}"/initramfs
         # shellcheck disable=SC2086
         cpio -id < ../initramfs.cpio ${DEBUG}
         # shellcheck disable=SC2086
@@ -885,7 +888,7 @@ if [ ! -e "${RPI_SB_WORKDIR}/bootfs-temporary.img" ] ||
             echo 'initramfs initramfs_2712' >> "${TMP_DIR}"/rpi-boot-img-mount/config.txt
             ;;
     esac
-    
+
     announce_stop "config.txt modification"
 
     announce_start "boot.img creation"


### PR DESCRIPTION
To add visibility into what is happening during the secure boot installation process it would be nice to get date and time prefix in logging.

Logs will looks like this:
```
sb-host /var/log/rpi-sb-provisioner/99435932 $ tail -n 3 triage.log
2025-03-03 15:51:57 Starting triage for /dev/bus/usb/003/008, serial: 99435932
2025-03-03 15:51:57 Observed provisioning state for 99435932: PROVISIONER-STARTED
2025-03-03 15:51:57 Not starting additional services, device already undergoing provisioning
sb-host /var/log/rpi-sb-provisioner/99435932 $ tail -n 3 provisioner.log
2025-03-03 15:52:21 ================================================================================
2025-03-03 15:52:21 Starting Erase / Partition Device Storage
2025-03-03 15:52:21 ================================================================================
sb-host /var/log/rpi-sb-provisioner/99435932 $ tail -n 3 keywriter.log
2025-03-03 15:51:53 Signing bootloader config
2025-03-03 15:51:54 Writing key and EEPROM configuration to the device
2025-03-03 15:51:54 Keywriting completed. Rebooting for next phase.
```