### PR TITLE
metadata: Correctly detect 16 GB memory variants

### DIFF
--- a/host-support/manufacturing-data
+++ b/host-support/manufacturing-data
@@ -66,6 +66,7 @@ metadata_gather() {
         "0x3") MEMORY_STR="2GB" ;;
         "0x4") MEMORY_STR="4GB" ;;
         "0x5") MEMORY_STR="8GB" ;;
+        "0x6") MEMORY_STR="16GB" ;;
         *)
             MEMORY_STR="Unknown"
     esac


### PR DESCRIPTION
Add missing identifier for 16 GB memory on pi5 / cm5.