### PR TITLE
docs: Update README for improved device provisioning instructions

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -329,8 +329,8 @@ You can watch devices being provisioned in real time:
 *Using the Web Interface:*
 
 1. Open http://localhost:3142 in your browser
-2. Click the *Services* tab
-3. You will see all active provisioning operations
+2. Click the *Devices* tab to see a live visual representation of provisioning progress for all connected devices
+3. Alternatively, click the *Services* tab to see all active provisioning operations
 4. Click on any device to see detailed logs
 
 *Using the Command Line:*


### PR DESCRIPTION
- Revised the steps for monitoring device provisioning in the web interface to enhance clarity.
- Added a new instruction to access a live visual representation of provisioning progress under the *Devices* tab.
- Clarified the alternative option to view active provisioning operations under the *Services* tab, improving user guidance.