### PR TITLE
debian: Add libjsoncpp-dev into Build-Depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: rpi-sb-provisioner
 Section: admin
 Priority: optional
 Maintainer: Tom Dewey <tom.dewey@raspberrypi.com>
-Build-Depends: debhelper (>= 13), cmake (>= 3.25), g++ (>= 10), libsqlite3-dev, libsystemd-dev, pandoc, asciidoctor, uuid-dev, libssl-dev
+Build-Depends: debhelper (>= 13), cmake (>= 3.25), g++ (>= 10), libsqlite3-dev, libjsoncpp-dev, libsystemd-dev, pandoc, asciidoctor, uuid-dev, libssl-dev
 Standards-Version: 4.7.2
 Homepage: https://www.raspberrypi.com/software
 


### PR DESCRIPTION
Building shows error:
```
CMake Error at /home/dev/rpi-sb-provisioner-src/rpi-sb-provisioner/obj-aarch64-linux-gnu/_deps/drogon-src/cmake_modules/FindJsoncpp.cmake:44 (message):
  Error: jsoncpp lib is too old.....stop
Call Stack (most recent call first):
  /home/dev/rpi-sb-provisioner-src/rpi-sb-provisioner/obj-aarch64-linux-gnu/_deps/drogon-src/CMakeLists.txt:190 (find_package)
```
rpi-sb-provisioner cannot be built until libjsoncpp-dev is installed.

Fixes: https://github.com/raspberrypi/rpi-sb-provisioner/issues/213