### PR TITLE
Make `IPV6_ADDRESS`  parsing easier to understand.

### DIFF
--- a/service/rpi-sb-common.sh
+++ b/service/rpi-sb-common.sh
@@ -135,7 +135,7 @@ setup_fastboot_and_id_vars() {
     USE_IPV4=
     USE_IPV6=
     set +e
-    IPV6_ADDRESS="$(fastboot -s "${FASTBOOT_DEVICE_SPECIFIER}" getvar ipv6-address 2>&1 | grep -oE '([0-9a-fA-F]{0,4}:){1,7}[0-9a-fA-F]{0,4}|::([0-9a-fA-F]{0,4}:){0,6}[0-9a-fA-F]{0,4}|[0-9a-fA-F]{0,4}::([0-9a-fA-F]{0,4}:){0,5}[0-9a-fA-F]{0,4}|([0-9a-fA-F]{0,4}:){1,2}:([0-9a-fA-F]{0,4}:){0,4}[0-9a-fA-F]{0,4}')"
+    IPV6_ADDRESS="$(fastboot -s "${FASTBOOT_DEVICE_SPECIFIER}" getvar ipv6-address 2>&1 | awk '/^ipv6-address:/ {print $2}')"
     (timeout_nonfatal fastboot -s tcp:"${IPV6_ADDRESS}" getvar version)
     USE_IPV6=$?
     IPV4_ADDRESS="$(fastboot -s "${FASTBOOT_DEVICE_SPECIFIER}" getvar ipv4-address 2>&1 | grep -oE '([0-9]{1,3}\.){3}[0-9]{1,3}')"


### PR DESCRIPTION
Here is an example log from when the parsing for the `IPV6_ADDRESS` fails, and falls back to the `IPV4_ADDRESS`:

```log
Jan 05 13:24:30 provisioner rpi-sb-provisioner.sh[119892]: + USE_IPV4=
Jan 05 13:24:30 provisioner rpi-sb-provisioner.sh[119892]: + USE_IPV6=
Jan 05 13:24:30 provisioner rpi-sb-provisioner.sh[119892]: + set +e
Jan 05 13:24:30 provisioner rpi-sb-provisioner.sh[123316]: + fastboot -s cef56e611dfefbba getvar ipv6-address
Jan 05 13:24:30 provisioner rpi-sb-provisioner.sh[123317]: + grep -oE ([0-9a-fA-F]{0,4}:){1,7}[0-9a-fA-F]{0,4}|::([0-9a-fA-F]{0,4}:){0,6}[0-9a-fA-F]{0,4}|[
0-9a-fA-F]{0,4}::([0-9a-fA-F]{0,4}:){0,5}[0-9a-fA-F]{0,4}|([0-9a-fA-F]{0,4}:){1,2}:([0-9a-fA-F]{0,4}:){0,4}[0-9a-fA-F]{0,4}
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[119892]: + IPV6_ADDRESS=:
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[119892]: fd6e:9ed6:afe1:1d00:2ecf:67ff:fecc:9fee
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[119892]: e:
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123318]: + timeout_nonfatal fastboot -s tcp::
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123318]: fd6e:9ed6:afe1:1d00:2ecf:67ff:fecc:9fee
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123318]: e: getvar version
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123318]: + command=fastboot -s tcp::
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123318]: fd6e:9ed6:afe1:1d00:2ecf:67ff:fecc:9fee
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123318]: e: getvar version
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123318]: + set +e
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123318]: + log Running command with 10-second timeout: "fastboot -s tcp::
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123318]: fd6e:9ed6:afe1:1d00:2ecf:67ff:fecc:9fee
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123318]: e: getvar version"
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123321]: + date +%N
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123322]: + cut -c1-3
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123319]: + date +%Y-%m-%d %H:%M:%S.006
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123318]: + timestamp=2026-01-05 13:24:31.006
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123318]: + echo [2026-01-05 13:24:31.006] Running command with 10-second timeout: "fastboot -s tcp::
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123318]: fd6e:9ed6:afe1:1d00:2ecf:67ff:fecc:9fee
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123318]: e: getvar version"
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123318]: + timeout 10 fastboot -s tcp:: fd6e:9ed6:afe1:1d00:2ecf:67ff:fecc:9fee e: getvar version
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123324]: fastboot: error: invalid network address ':': no host in ':'
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123318]: + command_exit_status=1
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123318]: + log "fastboot -s tcp::
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123318]: fd6e:9ed6:afe1:1d00:2ecf:67ff:fecc:9fee
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123318]: e: getvar version" FAILED: Command returned exit code 1.
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123327]: + date +%N
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123328]: + cut -c1-3
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123325]: + date +%Y-%m-%d %H:%M:%S.012
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123318]: + timestamp=2026-01-05 13:24:31.012
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123318]: + echo [2026-01-05 13:24:31.012] "fastboot -s tcp::
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123318]: fd6e:9ed6:afe1:1d00:2ecf:67ff:fecc:9fee
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123318]: e: getvar version" FAILED: Command returned exit code 1.
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123318]: + set -e
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123318]: + return 1
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[119892]: + USE_IPV6=1
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123330]: + fastboot -s cef56e611dfefbba getvar ipv4-address
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123331]: + grep -oE ([0-9]{1,3}\.){3}[0-9]{1,3}
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[119892]: + IPV4_ADDRESS=10.70.0.204
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123332]: + timeout_nonfatal fastboot -s tcp:10.70.0.204 getvar version
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123332]: + command=fastboot -s tcp:10.70.0.204 getvar version
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123332]: + set +e
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123332]: + log Running command with 10-second timeout: "fastboot -s tcp:10.70.0.204 getvar version"
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123335]: + date +%N
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123336]: + cut -c1-3
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123333]: + date +%Y-%m-%d %H:%M:%S.026
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123332]: + timestamp=2026-01-05 13:24:31.026
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123332]: + echo [2026-01-05 13:24:31.026] Running command with 10-second timeout: "fastboot -s
tcp:10.70.0.204 getvar version"
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123332]: + timeout 10 fastboot -s tcp:10.70.0.204 getvar version
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123338]: version: 0.4
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123338]: Finished. Total time: 0.006s
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123332]: + command_exit_status=0
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123332]: + log "fastboot -s tcp:10.70.0.204 getvar version" succeeded with exit code 0.
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123341]: + date +%N
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123342]: + cut -c1-3
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123339]: + date +%Y-%m-%d %H:%M:%S.038
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123332]: + timestamp=2026-01-05 13:24:31.038
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123332]: + echo [2026-01-05 13:24:31.038] "fastboot -s tcp:10.70.0.204 getvar version" succeeded with
exit code 0.
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123332]: + set -e
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[123332]: + return 0
Jan 05 13:24:31 provisioner rpi-sb-provisioner.sh[119892]: + USE_IPV4=0
```

The small change in this PR makes the `IPV6_ADDRESS` parsing correct, and easier to understand.

Now instead of capturing:
```
:
fd6e:9ed6:afe1:1d00:2ecf:67ff:fecc:9fee
e:
```
It will correctly capture just:
```
fd6e:9ed6:afe1:1d00:2ecf:67ff:fecc:9fee
```
The `IPV4_ADDRESS` might also benefit from this change,
```bash
IPV4_ADDRESS="$(fastboot -s "${FASTBOOT_DEVICE_SPECIFIER}" getvar ipv4-address 2>&1 | awk '/^ipv4-address:/ {print $2}')
```
but I left it unmodified because the grep is clearly working.