### PR TITLE
metadata_gather before post-flash for db access

### DIFF
--- a/service/rpi-fde-provisioner.sh
+++ b/service/rpi-fde-provisioner.sh
@@ -713,14 +713,14 @@ fastboot -s "${FASTBOOT_DEVICE_SPECIFIER}" flash "${RPI_DEVICE_STORAGE_TYPE}"p1 
 fastboot -s "${FASTBOOT_DEVICE_SPECIFIER}" flash mapper/cryptroot "${RPI_SB_WORKDIR}"/rootfs-temporary.simg
 announce_stop "Writing OS images"
 
+metadata_gather
+
 # Run customisation script for post-flash stage
 run_customisation_script "fde-provisioner" "post-flash" "${FASTBOOT_DEVICE_SPECIFIER}" "${TARGET_DEVICE_SERIAL}" "${RPI_DEVICE_STORAGE_TYPE}"
 
 announce_start "Set LED status"
 fastboot -s "${FASTBOOT_DEVICE_SPECIFIER}" oem led PWR 0
 announce_stop "Set LED status"
-
-metadata_gather
 
 record_state "${TARGET_DEVICE_SERIAL}" "${PROVISIONER_FINISHED}" "${TARGET_USB_PATH}"
 log "Provisioning completed. Remove the device from this machine."

--- a/service/rpi-naked-provisioner.sh
+++ b/service/rpi-naked-provisioner.sh
@@ -205,11 +205,12 @@ announce_start "Set LED status"
 fastboot -s "${FASTBOOT_DEVICE_SPECIFIER}" oem led PWR 0
 announce_stop "Set LED status"
 
+metadata_gather
+
 # Run post-flash customisation script
 run_customisation_script "naked-provisioner" "post-flash" "${FASTBOOT_DEVICE_SPECIFIER}" "${TARGET_DEVICE_SERIAL}" "${RPI_DEVICE_STORAGE_TYPE}"
 log "Post-flash customization script completed"
 
-metadata_gather
 record_state "${TARGET_DEVICE_SERIAL}" "${PROVISIONER_FINISHED}" "${TARGET_USB_PATH}"
 
 log "Provisioning completed. Remove the device from this machine."

--- a/service/rpi-sb-provisioner.sh
+++ b/service/rpi-sb-provisioner.sh
@@ -626,14 +626,14 @@ fastboot -s "${FASTBOOT_DEVICE_SPECIFIER}" flash "${RPI_DEVICE_STORAGE_TYPE}"p1 
 fastboot -s "${FASTBOOT_DEVICE_SPECIFIER}" flash mapper/cryptroot "${RPI_SB_WORKDIR}"/rootfs-temporary.simg
 announce_stop "Writing OS images"
 
+metadata_gather
+
 # Run customisation script for post-flash stage
 run_customisation_script "sb-provisioner" "post-flash" "${FASTBOOT_DEVICE_SPECIFIER}" "${TARGET_DEVICE_SERIAL}" "${RPI_DEVICE_STORAGE_TYPE}"
 
 announce_start "Set LED status"
 fastboot -s "${FASTBOOT_DEVICE_SPECIFIER}" oem led PWR 0
 announce_stop "Set LED status"
-
-metadata_gather
 
 record_state "${TARGET_DEVICE_SERIAL}" "${PROVISIONER_FINISHED}" "${TARGET_USB_PATH}"
 log "Provisioning completed. Remove the device from this machine."


### PR DESCRIPTION
Thoughts on performing `metadata_gather` prior to running the `post-fash.sh` customization script?

We have been running like this in production so that we can reliably access the metadata from the database for the currently provisioned device during the post flash customization phase of provisioning.

This affords us the ability query the local manufacturing database during post-flash customization, and then send that data to our cloud database, thereby automatically registering the new device with our production backend.

Here is a simplified excerpt from our production `post-flash.sh` illustrating the above:

```bash
log_info "Querying local manufacturing database at http://localhost:3142/api/v2/manufacturing"
LOCAL_DB_RESPONSE=$(curl -s -w "\n%{http_code}" "http://localhost:3142/api/v2/manufacturing")
LOCAL_DB_BODY=$(echo "$LOCAL_DB_RESPONSE" | sed '$d')
MFG_DATA_JSON=$(echo "$LOCAL_DB_BODY" | jq 'map(select(.serial == "'"$TARGET_DEVICE_SERIAL"'")) | .[0]')
log_info "Posting device to cloud backend..."
post_to_backend "$MFG_DATA_JSON" "$ENV"
```




