### PR TITLE
provisioners: Fixup error status capture in cleanup()

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -96,6 +96,19 @@ rpi-sb-provisioner (2.3.0) unstable; urgency=medium
       measurements) and Raspberry Pi Connect device identity
       registration; the private key never leaves the SoC
 
+  * Provisioner Exit Status Fix:
+    - Fix cleanup() trap handler in rpi-sb-provisioner.sh,
+      rpi-fde-provisioner.sh, rpi-naked-provisioner.sh,
+      rpi-idp-provisioner.sh and rpi-sb-bootstrap.sh swallowing the
+      real exit status: the re-entry guard and CLEANUP_DONE=1
+      assignment clobbered $? before it was captured, so any failure
+      caught by the trap (set -e, die, SIGTERM) was reported as
+      success -- the systemd unit showed "Deactivated successfully"
+      and the WebUI saw a clean run despite aborted provisioning
+    - Capture $? as the first statement of cleanup() so the original
+      exit status propagates through to systemd and the manufacturing
+      database
+
  -- Tom Dewey <tom.dewey@raspberrypi.com>  Fri, 17 Apr 2026 12:00:00 +0100
 
 rpi-sb-provisioner (2.2.0) unstable; urgency=medium

--- a/service/rpi-fde-provisioner.sh
+++ b/service/rpi-fde-provisioner.sh
@@ -223,11 +223,14 @@ check_pidevice_storage_type() {
 
 
 cleanup() {
+    # Capture the exit status that triggered the trap BEFORE any other
+    # command runs, otherwise $? is clobbered by the guard/assignment below
+    # and a genuine failure is reported as success.
+    returnvalue=$?
+
     # Guard against multiple invocations (signal + EXIT trap)
     [ "$CLEANUP_DONE" -eq 1 ] && return
     CLEANUP_DONE=1
-
-    returnvalue=$?
 
     # Disable errexit so cleanup runs to completion even if umount/sync fail
     set +e

--- a/service/rpi-idp-provisioner.sh
+++ b/service/rpi-idp-provisioner.sh
@@ -103,11 +103,15 @@ timeout_fatal_secs() {
 }
 
 cleanup() {
+    # Capture the exit status that triggered the trap BEFORE any other
+    # command runs, otherwise $? is clobbered by the guard/assignment below
+    # and a genuine failure is reported as success.
+    return_value=$?
+
     # Guard against multiple invocations (signal + EXIT trap)
     [ "$CLEANUP_DONE" -eq 1 ] && return
     CLEANUP_DONE=1
 
-    return_value=$?
     exit ${return_value}
 }
 trap cleanup EXIT INT TERM

--- a/service/rpi-naked-provisioner.sh
+++ b/service/rpi-naked-provisioner.sh
@@ -133,11 +133,14 @@ timeout_fatal() {
 }
 
 cleanup() {
+    # Capture the exit status that triggered the trap BEFORE any other
+    # command runs, otherwise $? is clobbered by the guard/assignment below
+    # and a genuine failure is reported as success.
+    return_value=$?
+
     # Guard against multiple invocations (signal + EXIT trap)
     [ "$CLEANUP_DONE" -eq 1 ] && return
     CLEANUP_DONE=1
-
-    return_value=$?
 
     # Disable errexit so cleanup runs to completion even if umount/sync fail
     set +e

--- a/service/rpi-sb-bootstrap.sh
+++ b/service/rpi-sb-bootstrap.sh
@@ -45,11 +45,14 @@ log() {
 CLEANUP_DONE=0
 
 cleanup() {
+    # Capture the exit status that triggered the trap BEFORE any other
+    # command runs, otherwise $? is clobbered by the guard/assignment below
+    # and a genuine failure is reported as success.
+    returnvalue=$?
+
     # Guard against multiple invocations (signal + EXIT trap)
     [ "$CLEANUP_DONE" -eq 1 ] && return
     CLEANUP_DONE=1
-
-    returnvalue=$?
     if [ ${HOLDING_LOCKFILE} -eq 1 ]; then
         rm -rf "$DEVICE_LOCK"
         

--- a/service/rpi-sb-provisioner.sh
+++ b/service/rpi-sb-provisioner.sh
@@ -247,11 +247,14 @@ check_pidevice_storage_type() {
 
 
 cleanup() {
+    # Capture the exit status that triggered the trap BEFORE any other
+    # command runs, otherwise $? is clobbered by the guard/assignment below
+    # and a genuine failure is reported as success.
+    returnvalue=$?
+
     # Guard against multiple invocations (signal + EXIT trap)
     [ "$CLEANUP_DONE" -eq 1 ] && return
     CLEANUP_DONE=1
-
-    returnvalue=$?
 
     # Disable errexit so cleanup runs to completion even if umount/sync fail
     set +e


### PR DESCRIPTION
Don't "exit 0" just because the logs printed successfully - capture the actual return code in cleanup.