### PR TITLE
debian/control: Add missing zlib1g-dev & libzstd-dev build dep

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: rpi-sb-provisioner
 Section: admin
 Priority: optional
 Maintainer: Tom Dewey <tom.dewey@raspberrypi.com>
-Build-Depends: debhelper-compat (= 13), cmake (>= 3.25), g++ (>= 10), libsqlite3-dev, libsystemd-dev, pandoc, asciidoctor, uuid-dev, libssl-dev
+Build-Depends: debhelper-compat (= 13), cmake (>= 3.25), g++ (>= 10), libsqlite3-dev, libsystemd-dev, pandoc, asciidoctor, uuid-dev, libssl-dev, libzstd-dev, zlib1g-dev
 Standards-Version: 4.7.2
 Homepage: https://www.raspberrypi.com/software
 


### PR DESCRIPTION
The rpi-sb-provisioner fails to build due to missed libraries:
```
CMake Error at /usr/share/cmake-3.31/Modules/FindPackageHandleStandardArgs.cmake:233 (message):
  Could NOT find ZLIB (missing: ZLIB_LIBRARY ZLIB_INCLUDE_DIR)
Call Stack (most recent call first):
  /usr/share/cmake-3.31/Modules/FindPackageHandleStandardArgs.cmake:603 (_FPHSA_FAILURE_MESSAGE)
  /usr/share/cmake-3.31/Modules/FindZLIB.cmake:202 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  /home/dev/rpi/rpi-sb-provisioner/obj-aarch64-linux-gnu/_deps/drogon-src/CMakeLists.txt:506 (find_package)
```
And,
```
[ 46%] Building C object _deps/libarchive-build/libarchive/CMakeFiles/archive_static.dir/archive_read_support_filter_zstd.c.o cd /home/dev/rpi/rpi-sb-provisioner/obj-aarch64-linux-gnu/_deps/libarchive-build/libarchive && /usr/bin/cc -DHAVE_CONFIG_H -DLIBARCHIVE_STATIC -D__LIBARCHIVE_ENABLE_VISIBILITY -I/home/dev/rpi/rpi-sb-provisioner/obj-aarch64-linux-gnu/_deps/libarchive-src/libarchive -I/home/dev/rpi/rpi-sb-provisioner/obj-aarch64-linux-gnu/_deps/libarchive-build -I/home/dev/rpi/rpi-sb-provisioner/obj-aarch64-linux-gnu/_deps/xz-src/src/liblzma/api -I/home/dev/rpi/rpi-sb-provisioner/obj-aarch64-linux-gnu/_deps/libarchive-src/libarchive/. -g -O2 -Werror=implicit-function-declaration -ffile-prefix-map=/home/dev/rpi/rpi-sb-provisioner=. -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -mbranch-protection=standard -Wdate-time -D_FORTIFY_SOURCE=2 -Wall -Wformat -Wformat-security -ffunction-sections -fdata-sections -fvisibility=hidden -O3 -DNDEBUG -MD -MT _deps/libarchive-build/libarchive/CMakeFiles/archive_static.dir/archive_read_support_filter_zstd.c.o -MF CMakeFiles/archive_static.dir/archive_read_support_filter_zstd.c.o.d -o CMakeFiles/archive_static.dir/archive_read_support_filter_zstd.c.o -c /home/dev/rpi/rpi-sb-provisioner/obj-aarch64-linux-gnu/_deps/libarchive-src/libarchive/archive_read_support_filter_zstd.c /home/dev/rpi/rpi-sb-provisioner/obj-aarch64-linux-gnu/_deps/libarchive-src/libarchive/archive_read_support_filter_zstd.c:46:10: fatal error: zstd.h: No such file or directory
   46 | #include <zstd.h>
      |          ^~~~~~~~
compilation terminated.
make[4]: *** [_deps/libarchive-build/libarchive/CMakeFiles/archive_static.dir/build.make:796: _deps/libarchive-build/libarchive/CMakeFiles/archive_static.dir/archive_read_support_filter_zstd.c.o] Error 1
```
So, install dependent package zlib1g-dev libzstd-dev for development.