### PR TITLE
provisioners: Update Connect terminology

### DIFF
--- a/provisioner-service/src/options.cpp
+++ b/provisioner-service/src/options.cpp
@@ -454,7 +454,7 @@ namespace provisioner {
                     // Reject values containing whitespace
                     if (fieldValue.find_first_of(" \t\r\n") != std::string::npos) {
                         jsonResponse["valid"] = false;
-                        jsonResponse["error"] = "API key must not contain whitespace";
+                        jsonResponse["error"] = "Management API access token must not contain whitespace";
                     }
                 }
             } else if (fieldName == "RPI_CONNECT_DESCRIPTION") {

--- a/provisioner-service/src/views/manufacturing.csp
+++ b/provisioner-service/src/views/manufacturing.csp
@@ -178,7 +178,7 @@
                             <th scope="col">OS Image Filename</th>
                             <th scope="col">OS Image SHA256</th>
                             <th scope="col">Connect Reg.</th>
-                            <th scope="col">Connect Device ID</th>
+                            <th scope="col">Connect Identity ID</th>
                         </tr>
                     </thead>
                     <tbody>

--- a/provisioner-service/src/views/options.csp
+++ b/provisioner-service/src/views/options.csp
@@ -1270,18 +1270,18 @@
                     <span class="section-title-icon">&#9729;</span>
                     Cloud Services
                 </h2>
-                <p class="section-description">Register provisioned devices with Raspberry Pi Connect. Requires an organisation API key from the Connect management portal.</p>
+                <p class="section-description">Register provisioned devices with Raspberry Pi Connect for Organisations. Requires a management API access token from the Settings tab of your Connect organisation.</p>
             </div>
 
             <!-- Connect API Key -->
             <div class="field-group">
-                <label class="field-label" for="RPI_CONNECT_API_KEY">Connect API Key <span class="optional-badge">Optional</span></label>
+                <label class="field-label" for="RPI_CONNECT_API_KEY">Connect Management API Access Token <span class="optional-badge">Optional</span></label>
                 <div class="pin-input-wrapper">
                     <input type="password" class="field-input" id="RPI_CONNECT_API_KEY" name="RPI_CONNECT_API_KEY"
                            value="<%c++ $$ << connectApiKey; %>"
-                           placeholder="Organisation API key from Raspberry Pi Connect"
+                           placeholder="rporg_..."
                            onblur="validateAndSaveField('RPI_CONNECT_API_KEY')">
-                    <button type="button" class="pin-toggle-visibility" onclick="toggleConnectKeyVisibility()" aria-label="Toggle API key visibility">&#128065;</button>
+                    <button type="button" class="pin-toggle-visibility" onclick="toggleConnectKeyVisibility()" aria-label="Toggle access token visibility">&#128065;</button>
                 </div>
                 <div id="feedback-RPI_CONNECT_API_KEY" class="field-feedback"></div>
 
@@ -1302,7 +1302,7 @@
 
                 <div class="inline-help">
                     <span class="inline-help-icon">&#9432;</span>
-                    <span>Optional prefix for the device description sent to Connect. The board type and serial number are always appended.</span>
+                    <span>Optional prefix for the device identity description sent to Connect. The board type and serial number are always appended.</span>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
For consistency with Connect's UI and documentation, be specific about the Connect for Organisations management API, its access tokens, and how they relate to device identities.

Note we draw a distinction between a device and its identity as the ID returned when registering a device identity will not match the resulting device's ID.
