### PR TITLE
docs: Enhance README and API documentation for IDP artefacts and key …

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ All data on the device storage is encrypted using full-disk encryption. If the s
 
 The tool automatically deploys your custom Raspberry Pi operating system to each device. You create a single master image, and the tool replicates it to all provisioned devices with appropriate security modifications.
 
+Traditional uncompressed `.img` files and IDP (Image Description Provisioning) artefacts produced by `rpi-image-gen` are both supported. IDP artefacts carry their partition layout, encryption and storage metadata in the image descriptor, so the WebUI can derive those settings from the selected image.
+
 ## 4. Manufacturing Records
 
 The tool can maintain a manufacturing database recording details about each provisioned device. This includes serial numbers, MAC addresses, provisioning timestamps, and security configuration. This data supports inventory tracking, warranty management, and customer support operations.
@@ -173,7 +175,7 @@ You need to set these options:
 
 - **Signing key:** For secure boot mode, you need a signing key (the web interface will guide you through creating one)
 
-- **OS Image:** Upload a "master" operating system image. This is the operating system that will be installed on all your devices. The image must be created with `pi-gen` (see <https://github.com/RPi-Distro/pi-gen>) and must be **uncompressed** (not a `.zip` or `.gz` file)
+- **OS Image:** Upload a "master" operating system image. For traditional provisioning this is an uncompressed `.img` file, typically created with `pi-gen` (see <https://github.com/RPi-Distro/pi-gen>). You can also upload an IDP artefact archive (`.tar.xz`, `.tar.zst`, `.tar.gz`, `.tgz` or `.zip`) produced by `rpi-image-gen`; the WebUI extracts it and uses its metadata to configure the device family, storage type and encryption settings.
 
 - **Device firmware:** Select the firmware version to use for your devices
 
@@ -260,11 +262,21 @@ The tool works in three automatic phases:
 
 - Selected security mode is determined from configuration
 
+- The device unique secret is provisioned and locked if needed. This hardware-held device identity is used by encrypted-root unlock and Raspberry Pi Connect registration.
+
 - Appropriate provisioning service is started
 
 **Phase 3: Provisioning**
 
 Operations performed depend on the selected security mode:
+
+- **IDP artefact selected:**
+
+  - Reads the image descriptor and sparse image files produced by `rpi-image-gen`
+
+  - Uses the device-side IDP fastboot protocol to create partitions, encryption metadata and flash sparse images
+
+  - For secure-boot IDP images, signs the boot slots and prepares the signed boot chain
 
 - **secure-boot mode:**
 
@@ -394,9 +406,9 @@ Sometimes old files cause problems. Clear the cache:
 
 **Command line:**
 
-    sudo rm -rf /var/lock/rpi-sb-provisioner/<serial>
+    sudo find /srv/rpi-sb-provisioner/workdir -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +
 
-Replace `<serial>` with your device serial number.
+If you configured `RPI_SB_WORKDIR` to a different path, use that directory instead. Package upgrades and changes to the selected firmware or signing key also invalidate cached signed artefacts automatically.
 
 ### Step 3: Try Again
 
@@ -483,6 +495,8 @@ The database stores information about each device:
 - Which OS image was installed
 
 - Security settings
+
+- Raspberry Pi Connect registration status and device ID, when Connect registration is configured
 
 ### Viewing The Database
 

--- a/docs/api/configuration.md
+++ b/docs/api/configuration.md
@@ -16,7 +16,8 @@ The Configuration API provides endpoints for managing system configuration optio
   "RPI_SB_WORKDIR": "/srv/rpi-sb-provisioner/work",
   "RPI_SB_PROVISIONER_MANUFACTURING_DB": "/srv/rpi-sb-provisioner/manufacturing.db",
   "RPI_DEVICE_FAMILY": "5",
-  "RPI_DEVICE_FIRMWARE_FILE": "/lib/firmware/raspberrypi/bootloader-2712/default/pieeprom-2025-01-17.bin"
+  "RPI_DEVICE_FIRMWARE_FILE": "/lib/firmware/raspberrypi/bootloader-2712/default/pieeprom-2025-01-17.bin",
+  "RPI_CONNECT_API_KEY": ""
 }
 ```
 
@@ -64,7 +65,7 @@ HTTP 200 OK with no body on success.
 
 - Automatically creates manufacturing database file if path is set and file doesn’t exist
 
-- Clears working directory contents if `RPI_SB_WORKDIR` is modified
+- Clears working directory contents if `RPI_SB_WORKDIR`, selected firmware, or signing-key settings are modified
 
 # /options/validate
 
@@ -116,7 +117,7 @@ File Path Fields (must exist and be readable):
 
 - `CUSTOMER_KEY_FILE_PEM` - RSA private key file
 
-- `GOLD_MASTER_OS_FILE` - Must have .img extension (mandatory)
+- `GOLD_MASTER_OS_FILE` - Must be a traditional `.img` file or an IDP artefact directory containing exactly one valid JSON image descriptor and its referenced sparse images
 
 - `RPI_DEVICE_BOOTLOADER_CONFIG_FILE` - Bootloader configuration file
 
@@ -140,9 +141,13 @@ Enumerated Values:
 
 - `RPI_DEVICE_STORAGE_CIPHER` - Must be `aes-xts-plain64` or `xchacha12,aes-adiantum-plain64`
 
+- `RPI_DEVICE_RPIBOOT_GPIO` - For Raspberry Pi 4 family secure-boot provisioning, must be one of `2`, `4`, `5`, `6`, `7`, or `8`
+
 Format-Specific:
 
 - `CUSTOMER_KEY_PKCS11_NAME` - Must start with `pkcs11:` and include `object=` and `type=private` parameters
+
+- `RPI_CONNECT_API_KEY` - Must not contain whitespace
 
 **Security Measures:**
 
@@ -171,6 +176,229 @@ Format-Specific:
 - Does not modify configuration - use `/options/set` to save values
 
 - Failed validation attempts for unknown fields are logged as security warnings
+
+# Key And Secret Management
+
+## /options/upload-key
+
+**HTTP Method:** POST
+
+**Description:** Uploads a PEM signing key and updates `CUSTOMER_KEY_FILE_PEM`.
+
+**Request Format:**
+
+Multipart form data containing the PEM key file.
+
+**Response Format:**
+
+``` json
+{
+  "success": true,
+  "path": "/etc/rpi-sb-provisioner/keys/customer-key.pem",
+  "filename": "customer-key.pem",
+  "keyInfo": {
+    "algorithm": "RSA",
+    "keySize": 2048,
+    "isPrivateKey": true,
+    "fingerprint": "sha256:...",
+    "isFitForPurpose": true
+  }
+}
+```
+
+**Notes:**
+
+- Uploaded PEM keys are device-wrapped at rest before the handler returns. If device wrapping fails, the upload is rejected and the plaintext file is removed.
+
+- Uploading a PEM key clears `CUSTOMER_KEY_PKCS11_NAME`
+
+## /options/validate-key
+
+**HTTP Method:** POST
+
+**Description:** Validates either a PEM key file or a PKCS#11 URI and returns key metadata.
+
+**Request Format:**
+
+For a PEM key:
+
+``` json
+{
+  "path": "/etc/rpi-sb-provisioner/keys/customer-key.pem"
+}
+```
+
+For a PKCS#11 key:
+
+``` json
+{
+  "uri": "pkcs11:object=my-signing-key;type=private",
+  "pin": "optional-pin"
+}
+```
+
+**Response Format:**
+
+``` json
+{
+  "keyType": "pkcs11",
+  "keyInfo": {
+    "algorithm": "RSA",
+    "keySize": 2048,
+    "isPrivateKey": true,
+    "fingerprint": "sha256:...",
+    "isFitForPurpose": true,
+    "statusMessage": "Key is suitable for Raspberry Pi secure boot signing",
+    "statusLevel": "success",
+    "valid": true
+  }
+}
+```
+
+## /options/pkcs11-status
+
+**HTTP Method:** GET
+
+**Description:** Reports whether the OpenSSL `pkcs11-provider` is installed and loadable. This does not touch a token and does not require a PIN.
+
+**Response Format:**
+
+``` json
+{
+  "providerAvailable": true
+}
+```
+
+## /options/pkcs11-discover
+
+**HTTP Method:** POST
+
+**Description:** Enumerates key objects visible to `pkcs11-provider` through p11-kit so the WebUI can offer a key picker.
+
+**Request Format:**
+
+``` json
+{
+  "pin": "optional-pin"
+}
+```
+
+The request body is optional. If no PIN is supplied, the service uses the stored PIN if one is configured.
+
+**Response Format:**
+
+``` json
+{
+  "providerAvailable": true,
+  "objects": [
+    {
+      "uri": "pkcs11:token=token-label;object=my-signing-key;type=private",
+      "label": "my-signing-key",
+      "token": "token-label",
+      "type": "private"
+    }
+  ]
+}
+```
+
+If discovery fails, the response may include `errorMessage`.
+
+## /options/pkcs11-pin-status
+
+**HTTP Method:** GET
+
+**Description:** Reports whether an HSM PIN is stored. The PIN value is never returned.
+
+**Response Format:**
+
+``` json
+{
+  "configured": true
+}
+```
+
+## /options/set-pkcs11-pin
+
+**HTTP Method:** POST
+
+**Description:** Stores or removes the HSM PIN used for PKCS#11 signing.
+
+**Request Format:**
+
+``` json
+{
+  "pin": "123456"
+}
+```
+
+An empty `pin` removes the stored PIN.
+
+**Response Format:**
+
+``` json
+{
+  "success": true,
+  "configured": true
+}
+```
+
+**Notes:**
+
+- Stored PINs are device-wrapped at rest when firmware crypto support is available
+
+- The PIN is never returned by the API
+
+## /options/encryption-status
+
+**HTTP Method:** GET
+
+**Description:** Reports whether configured local secrets are present and device-wrapped at rest.
+
+**Response Format:**
+
+``` json
+{
+  "pin": {
+    "configured": true,
+    "wrapped": true
+  },
+  "key": {
+    "configured": true,
+    "wrapped": true
+  },
+  "anyUnwrapped": false
+}
+```
+
+## /options/migrate-secrets
+
+**HTTP Method:** POST
+
+**Description:** Device-wraps previously plaintext stored secrets in place.
+
+**Request Format:**
+
+``` json
+{
+  "target": "all"
+}
+```
+
+`target` may be `pin`, `key`, or `all`. If omitted, `all` is used.
+
+**Response Format:**
+
+``` json
+{
+  "success": true,
+  "pin": {
+    "migrated": true
+  },
+  "key": {
+    "migrated": true
+  }
+}
+```
 
 # /options/clear-workdir
 

--- a/docs/api/customisation.md
+++ b/docs/api/customisation.md
@@ -245,11 +245,15 @@ Plain text success message: "Script file uploaded successfully"
 
 ``` json
 {
-  "provisioners": ["sb-provisioner", "fde-provisioner", "naked-provisioner"],
+  "provisioners": ["sb-provisioner", "fde-provisioner", "naked-provisioner", "idp-provisioner"],
   "stages": [
     {
       "name": "bootstrap",
       "description": "Executed when a device is detected, before provisioning begins"
+    },
+    {
+      "name": "provision-started",
+      "description": "Executed at the start of provisioning, before image preparation"
     },
     {
       "name": "bootfs-mounted",
@@ -271,6 +275,10 @@ Plain text success message: "Script file uploaded successfully"
 **Notes:**
 
 - This endpoint provides a comprehensive list of all possible customisation points
+
+- `sb-provisioner`, `fde-provisioner`, and `naked-provisioner` support `bootstrap`, `provision-started`, `bootfs-mounted`, `rootfs-mounted`, and `post-flash`
+
+- `idp-provisioner` supports `provision-started` and `post-flash`; IDP provisioning does not expose host-side `bootfs-mounted` or `rootfs-mounted` stages because partition creation and encryption are handled by fastbootd on the device
 
 - The `exists` field indicates whether a script file currently exists for that hook
 

--- a/docs/api/manufacturing.md
+++ b/docs/api/manufacturing.md
@@ -41,6 +41,12 @@ The endpoint returns a JSON array where each element represents a provisioned de
     "signed_boot_enabled": "1",
     "os_image_filename": "raspios-2025-04-01.img",
     "os_image_sha256": "4f2d9c5b0e3b1d8a9c1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c",
+    "connect_registered": "1",
+    "connect_device_id": "device-123456",
+    "eeprom_size": 524288,
+    "eeprom_jedec": "ef4018",
+    "eeprom_unique_id": "0123456789abcdef",
+    "bootloader_build_timestamp": 1780326171,
     "provision_ts": "2025-04-28 13:53:28"
   },
   ...
@@ -70,6 +76,14 @@ The endpoint returns a JSON array where each element represents a provisioned de
 | pubkey_programmed      | Customer public key programming status (1=programmed, 0=not programmed, null=unknown). Observed via fastboot `getvar secure-otp`.                                                                                                                       |
 | devkey_revoked         | Development-key revocation status (1=revoked, 0=not revoked, null=unknown). Observed via fastboot `getvar secure-devkey`.                                                                                                                               |
 | signed_boot_enabled    | Signed boot enforcement status (1=enabled, 0=disabled, null=unknown). Derived from `pubkey_programmed` — firmware authenticates boot.img only when the customer pubkey hash is in OTP.                                                                  |
+| os_image_filename      | OS image filename or IDP image summary used during provisioning                                                                                                                                                                                           |
+| os_image_sha256        | SHA256 of the traditional OS image, or the original uploaded IDP archive hash stored in its sidecar file                                                                                                                                                  |
+| connect_registered     | Raspberry Pi Connect registration result (1=registered, 0=not registered or registration failed, null=not attempted). Registration failures are non-fatal.                                                                                                |
+| connect_device_id      | Raspberry Pi Connect device ID returned by the management API, when registration succeeds                                                                                                                                                                 |
+| eeprom_size            | EEPROM size in bytes, when reported by fastboot                                                                                                                                                                                                          |
+| eeprom_jedec           | EEPROM JEDEC identifier, when reported by fastboot                                                                                                                                                                                                       |
+| eeprom_unique_id       | EEPROM unique identifier, when reported by fastboot                                                                                                                                                                                                      |
+| bootloader_build_timestamp | Bootloader build timestamp, when reported by fastboot                                                                                                                                                                                                |
 | provision_ts           | Timestamp of when the device was provisioned                                                                                                                                                                                                            |
 
 **Example Usage:**
@@ -115,4 +129,4 @@ On error, the endpoint returns a JSON object with error details:
 
 - For large datasets, it is recommended to use pagination to improve performance.
 
-- The database path is configured using the [RPI_SB_PROVISIONER_MANUFACTURING_DB](config_vars.xml#rpi_sb_provisioner_manufacturing_db) setting as described in the configuration documentation.
+- The database path is configured using the [RPI_SB_PROVISIONER_MANUFACTURING_DB](../config_vars.md#rpi_sb_provisioner_manufacturing_db) setting as described in the configuration documentation.

--- a/docs/api_endpoints.md
+++ b/docs/api_endpoints.md
@@ -86,7 +86,7 @@ Monitor provisioning services running on the system, retrieve service logs with 
 
 ## [Images API](api/images.md)
 
-Complete lifecycle management of OS images including upload, download, metadata retrieval, and asynchronous SHA256 hash calculation with real-time progress updates.
+Complete lifecycle management of OS images and IDP artefacts, including upload, download, metadata retrieval, asynchronous SHA256 hash calculation, and IDP descriptor analysis.
 
 **Key Endpoints:**
 
@@ -100,17 +100,37 @@ Complete lifecycle management of OS images including upload, download, metadata 
 
 - `POST /delete-image` - Delete images
 
+- `GET /analyze-image` - Analyze traditional images or IDP artefact directories
+
 **Use Cases:** Image management, integrity verification, automated image deployment
 
 ## [Configuration API](api/configuration.md)
 
-Manage system configuration options, firmware selection for different device families, and working directory management.
+Manage system configuration options, firmware selection for different device families, key/HSM settings, secret wrapping status, and working directory management.
 
 **Key Endpoints:**
 
 - `GET /options/get` - Retrieve all configuration values
 
 - `POST /options/set` - Update configuration
+
+- `POST /options/validate` - Validate a configuration field
+
+- `POST /options/upload-key` - Upload and validate a PEM signing key
+
+- `POST /options/validate-key` - Validate PEM or PKCS#11 signing keys
+
+- `GET /options/pkcs11-status` - Check OpenSSL PKCS#11 provider readiness
+
+- `POST /options/pkcs11-discover` - Discover HSM key objects through p11-kit
+
+- `GET /options/pkcs11-pin-status` - Check whether an HSM PIN is stored
+
+- `POST /options/set-pkcs11-pin` - Store or remove an HSM PIN
+
+- `GET /options/encryption-status` - Report device-wrapped secret status
+
+- `POST /options/migrate-secrets` - Device-wrap previously plaintext stored secrets
 
 - `POST /options/clear-workdir` - Clear working directory contents
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -119,7 +119,7 @@ Provisioning proceeds through three phases, each implemented as a systemd templa
 
 **Key operations:**
 \* Verify device is in fastboot mode
-\* Provision device firmware crypto ECDSA key (`oem fwcrypto init`) if not already present — every provisioned device receives one regardless of provisioning style, as it is used for HMAC-based LUKS key derivation and device identity
+\* Provision the device unique secret (`oem fwcrypto init`) if not already present — every provisioned device receives one regardless of provisioning style, as it is used for HMAC-based LUKS key derivation and device identity
 \* Capture device keypair (private and public keys) to the log directory or a configured retrieval path
 \* Read configuration to determine provisioning route:
 - If `GOLD_MASTER_OS_FILE` points to a directory (IDP artefact), start `rpi-idp-provisioner@.service` regardless of `PROVISIONING_STYLE`
@@ -160,7 +160,7 @@ Four variants implement different security and deployment models:
 
 - Erase device storage via fastboot
 
-- Create device-unique encryption key and store in OTP memory
+- Use the device unique secret to derive the LUKS unlock material
 
 - Partition and format storage
 
@@ -178,7 +178,7 @@ Four variants implement different security and deployment models:
 
 - Erase device storage via fastboot
 
-- Create device-unique encryption key and store in OTP memory
+- Use the device unique secret to derive the LUKS unlock material
 
 - Partition and format storage
 
@@ -303,6 +303,8 @@ A web service provides monitoring, configuration, and API access.
 
 - `/get-images`, `/analyze-image` - OS image management (traditional and IDP artefacts)
 
+- `/internal/state-changed`, `/internal/manufacturing-recorded` - Local-only notifications from provisioning scripts to refresh WebUI state promptly
+
 **WebSocket endpoints:**
 
 - `/ws/devices` - Real-time device topology updates
@@ -323,7 +325,7 @@ A web service provides monitoring, configuration, and API access.
 
 - **Separation of concerns:** Web service only monitors; shell scripts do the work
 
-- **No privilege escalation:** Web service runs as unprivileged user; uses sudo only for specific read operations
+- **Local-only privileged service:** The Web service runs as the system service user and performs configuration, key-storage and database operations directly. Internal notification endpoints are restricted to loopback clients and a per-boot shared token.
 
 - **Standard protocols:** HTTP REST API and WebSockets for integration
 
@@ -348,6 +350,18 @@ Simple key-value file format:
 **Modified by:** Web service or manual editing
 
 **Why:** Simple, transparent, version-controllable, easy to backup
+
+PEM signing keys uploaded through the WebUI and stored HSM PINs are device-wrapped at rest using a key derived from the provisioning Raspberry Pi firmware crypto device key. PKCS#11/HSM keys are referenced by URI and used through OpenSSL `pkcs11-provider`.
+
+### Signing Helpers
+
+Secure-boot signing can use either a PEM key or a PKCS#11 URI:
+
+- `rpi-sb-pem-sign.sh` invokes `rpi-sb-keyhelper`, which unwraps a device-wrapped PEM key in process memory and emits the RSA SHA-256 signature expected by Raspberry Pi signing tools.
+
+- `rpi-sb-pkcs11-sign.sh` invokes OpenSSL with `pkcs11-provider` and `default` providers, resolving the configured `pkcs11:` URI through `OSSL_STORE`.
+
+This keeps persistent PEM key material encrypted at rest and avoids the deprecated OpenSSL ENGINE path for HSM signing.
 
 ### State Tracking (`/var/run/rpi-sb-state/`)
 
@@ -455,9 +469,9 @@ The boot process implements cryptographic verification at each stage:
 
 - **Encrypted storage:** All OS data protected by LUKS2 encryption
 
-- **Device-unique keys:** Each device has unique encryption key stored in OTP memory
+- **Device unique secret:** Each device has hardware-held secret material used to derive its LUKS unlock secret
 
-- **Automatic unlock:** Pre-boot environment retrieves decryption key from OTP memory; no user interaction required
+- **Automatic unlock:** The pre-boot environment uses rpifwcrypto to derive the unlock secret; no user interaction required
 
 - **Minimal pre-boot environment:** Contains only kernel and modules necessary for LUKS unlock and pivot_root
 
@@ -469,9 +483,9 @@ The boot process implements cryptographic verification at each stage:
 
 - **Storage extraction:** Removing storage and reading it on another system yields only encrypted data
 
-- **Key extraction from storage:** Decryption key is stored in device OTP memory, not on storage device
+- **Key extraction from storage:** LUKS unlock material is derived from device hardware state, not stored on the storage device
 
-- **Device cloning:** Decryption keys are unique per device and stored in OTP; cannot clone storage to another device
+- **Device cloning:** Derived unlock material is unique per device, so cloning storage to another device does not make it decryptable
 
 - **Boot chain tampering:** Any modification to EEPROM bootloader or pre-boot environment will fail signature verification
 
@@ -781,7 +795,7 @@ WebSocket API provides real-time updates for dashboards and monitoring tools.
 
 **Critical data to backup:**
 
-- Customer signing keys (`CUSTOMER_KEY_FILE_PEM`)
+- Customer signing keys (`CUSTOMER_KEY_FILE_PEM`). If the key is device-wrapped, it is intentionally bound to the provisioning Raspberry Pi that wrapped it; keep an offline copy or HSM-backed key available according to your recovery plan.
 
 - Configuration file (`/etc/rpi-sb-provisioner/config`)
 

--- a/docs/boot-img-generator.md
+++ b/docs/boot-img-generator.md
@@ -206,6 +206,8 @@ Example version progression:
 
 - The signing key must be the same one used during initial provisioning
 
+- PEM signing keys uploaded through the WebUI may be stored device-wrapped at rest. The generator uses the provisioner's signing helpers, so wrapped PEM keys and PKCS#11 keys are both supported without manually decrypting key material.
+
 - Generated files and packages should be handled as sensitive material
 
 - Debian packages contain the source image filename and SHA256 in the changelog for traceability
@@ -230,6 +232,8 @@ CUSTOMER_KEY_FILE_PEM=/path/to/customer-key.pem
 # OR
 CUSTOMER_KEY_PKCS11_NAME='pkcs11:object=<keypair-alias>;type=private'
 ```
+
+`CUSTOMER_KEY_FILE_PEM` may point at a device-wrapped key uploaded through the WebUI. `CUSTOMER_KEY_PKCS11_NAME` is resolved through OpenSSL `pkcs11-provider`; register the HSM module with p11-kit as described in the [Configuration Reference](config_vars.md#making-your-hsm-available).
 
 ## Package Metadata Configuration
 
@@ -368,7 +372,7 @@ journalctl -u rpi-sb-image-bootimg-generator@<image-filename>.service -n 100
 |          |                                                          |
 |----------|----------------------------------------------------------|
 | Cause    | `CUSTOMER_KEY_FILE_PEM` points to a non-existent file    |
-| Solution | Verify the key file path and ensure the file is readable |
+| Solution | Verify the key file path and ensure the file is readable by the provisioner |
 
 # Package Management
 

--- a/docs/config_vars.md
+++ b/docs/config_vars.md
@@ -6,7 +6,7 @@ This document describes the configuration variables used in /etc/rpi-sb-provisio
 
 **Mandatory, with a default**
 
-Select the provisioning style you wish to use. Supported values are `secure-boot`, `fde-only` and `naked`. For details on what each provisioning style does, see the [main documentation](../README.xml#using-rpi-sb-provisioner).
+Select the provisioning style you wish to use. Supported values are `secure-boot`, `fde-only` and `naked`. For details on what each provisioning style does, see the [main documentation](../README.md#three-levels-of-security).
 
 If `PROVISIONING_STYLE` is not specified, it defaults to `secure-boot`.
 
@@ -14,17 +14,17 @@ If `PROVISIONING_STYLE` is not specified, it defaults to `secure-boot`.
 
 **Optional, mandatory if CUSTOMER_KEY_PKCS11_NAME is not set**
 
-The fully qualified path to your signing key, encoded in PEM format. This file is expected to contain an RSA 2048-bit Private Key.
+The fully qualified path to your signing key, encoded in PEM format. This file is expected to contain an RSA 2048-bit private key.
 
 > **Warning**
 >
-> This file should be considered key material, and should be protected while at rest and in use according to your threat model.
+> This file should be considered key material. When uploaded through the WebUI it is stored device-wrapped at rest, using a key derived from the provisioning Raspberry Pi firmware crypto device key. The plaintext key is still present in process memory while signing, so protect the provisioner host according to your threat model.
 
 ## CUSTOMER_KEY_PKCS11_NAME
 
 **Optional, mandatory if CUSTOMER_KEY_FILE_PEM is not set**
 
-The keypair alias for a PKCS11 keypair, typically stored on a Hardware Security Module (HSM) and provided through a helper tool. This is expected to act in place of the RSA 2048-bit Private key specified with CUSTOMER_KEY_FILE_PEM, and will be used as the signing device for all future pre-boot authentication images.
+The keypair alias or URI for a PKCS#11 keypair, typically stored on a Hardware Security Module (HSM). This acts in place of the RSA 2048-bit private key specified with `CUSTOMER_KEY_FILE_PEM`, and is used as the signing device for all future pre-boot authentication images.
 
 The value should take the format:
 
@@ -36,7 +36,7 @@ The value should take the format:
 
 > **Warning**
 >
-> The PKCS11 provider, and it’s associated HSM, should be considered key material and should be protected while at rest and in use according to your threat model.
+> The PKCS#11 provider, its associated HSM, and any PIN used to unlock it should be considered key material and protected according to your threat model.
 
 ### Making your HSM available
 
@@ -56,7 +56,7 @@ To confirm the token is discoverable, and to find the object alias for the `CUST
 
 > **Note**
 >
-> If the token requires a PIN, the signing operations read it from the URI — append a `pin-value=<PIN>` (or `pin-source=<file>`) attribute to `CUSTOMER_KEY_PKCS11_NAME`. The web UI can additionally take a PIN when validating a key. Treat any stored PIN as key material and protect it accordingly.
+> If the token requires a PIN, the WebUI can store it for signing operations. Stored PINs are device-wrapped at rest using the provisioning Raspberry Pi firmware crypto device key. You may still append a `pin-value=<PIN>` or `pin-source=<file>` attribute to `CUSTOMER_KEY_PKCS11_NAME` for deployments that manage PIN material outside the provisioner.
 
 ## GOLD_MASTER_OS_FILE
 
@@ -78,7 +78,7 @@ This should be your 'gold master' OS image. This can be either:
 
 > **Note**
 >
-> When selecting an IDP artefact through the WebUI, the device family, storage type, and cipher fields are locked to the values defined in the artefact’s metadata and cannot be overridden.
+> When selecting an IDP artefact through the WebUI, image metadata is used to pre-fill the device family, storage type, and cipher fields. Fields defined by the artefact are treated as the image defaults; the WebUI may still allow supported overrides such as storage type when the artefact and device support them.
 
 ## RPI_DEVICE_STORAGE_TYPE
 
@@ -193,7 +193,7 @@ See the [Raspberry Pi 4 Connection Guide](device-guidance/pi4.md) for more infor
 
 Store manufacturing data in a sqlite3 database. This will include the board serial, board revision, the boot ROM version, the MAC address of the ethernet port, any set hash of the customer signing key, the JTAG lock state, the board attributes and the advanced boot flags. It will also include the OS image filename and its SHA256 used during provisioning.
 
-You must not specify the path of a database stored on a network drive or similar storage, as this mechanism is only safe to use on a single provisioning system. For merging the output with multiple provisioning systems, consider [Processing the manufacturing database](../README.xml#_processing_the_manufacturing_database) in the main documentation.
+You must not specify the path of a database stored on a network drive or similar storage, as this mechanism is only safe to use on a single provisioning system. For merging the output with multiple provisioning systems, consider [Working With The Manufacturing Database](../README.md#working-with-the-manufacturing-database) in the main documentation.
 
 Set to the path of a file to contain a SQLite database stored on local storage. The WebUI will create this file if it does not exist.
 
@@ -202,6 +202,22 @@ Set to the path of a file to contain a SQLite database stored on local storage. 
 > If you are not using the WebUI, you must create this file before execution, for example using `touch`:
 
     $ touch ${RPI_SB_PROVISIONER_MANUFACTURING_DB}
+
+## RPI_CONNECT_API_KEY
+
+**Optional**
+
+Raspberry Pi Connect management API access token. When configured, provisioned devices are registered with Raspberry Pi Connect during provisioning.
+
+Registration uses hardware-backed firmware crypto signing. The signing material remains hardware-held on the device, and Connect registration failures are logged as warnings rather than aborting provisioning.
+
+The token must not contain whitespace. The WebUI stores it in `/etc/rpi-sb-provisioner/config`, so protect provisioner host access accordingly.
+
+## RPI_CONNECT_DESCRIPTION
+
+**Optional**
+
+Description prefix used when registering devices with Raspberry Pi Connect. The provisioner appends device-specific information such as board type and serial number.
 
 ## RPI_DEVICE_RETRIEVE_KEYPAIR
 
@@ -304,6 +320,10 @@ To enable this endpoint (NOT RECOMMENDED):
 Set to a location to cache OS assets between provisioning sessions. Recommended for use in production. For example:
 
     /srv/rpi-sb-provisioner/workdir
+
+The workdir contains signed boot images, signed bootfiles, EEPROM staging assets and other expensive intermediate artefacts. `rpi-sb-provisioner` invalidates cached signed artefacts when the selected firmware or signing keys change, and package upgrades clear cached artefacts under this directory while preserving the directory itself.
+
+Persistent data such as uploaded images, manufacturing databases, state databases, logs and configuration are not stored in the workdir and are not removed by workdir cache invalidation.
 
 # Format of the config file
 


### PR DESCRIPTION
…management

- Updated README.md to include support for IDP artefacts and their metadata handling in the WebUI.
- Enhanced API documentation to reflect new endpoints for managing IDP artefacts and key validation.
- Clarified the handling of PEM and PKCS#11 keys, emphasizing device-wrapping and security measures.
- Added details on Raspberry Pi Connect registration status in manufacturing records.
- Improved descriptions and examples across various configuration and API documents for better clarity.