### PR TITLE
Fix: skip EEPROM config signing for naked provisioning (fixes #319)

### DIFF
--- a/service/rpi-sb-bootstrap.sh
+++ b/service/rpi-sb-bootstrap.sh
@@ -391,7 +391,7 @@ update_eeprom() {
 
     log "update_eeprom() src_image: \"${src_image}\""
 
-    if signing_available; then
+    if signing_available && [ "${PROVISIONING_STYLE}" != "naked" ]; then
         if ! grep -q "SIGNED_BOOT=1" "${RPI_DEVICE_BOOTLOADER_CONFIG_FILE}"; then
             # If the OTP bit to require secure boot are set then then
             # SIGNED_BOOT=1 is implicitly set in the EEPROM config.


### PR DESCRIPTION
## Problem

In 2.3.1, `update_eeprom()` signs the bootloader config (and, on 2712, bootcode/bootsys)
whenever a customer key is configured — regardless of `PROVISIONING_STYLE`. In naked mode
this produces an EEPROM containing a signed config block with an embedded public key,
while the device OTP remains unprogrammed (`CUSTOMER_KEY_HASH` all zeros). The resulting
device does not boot: solid red power LED, no green activity, no diagnostic blink code.
The provisioner reports `EEPROM_UPDATE: success`.

This is the root cause of #319 (reported on NVMe; reproduced identically on SD).

## Evidence

Reproduced on two independent provisioning hosts (identical stacks: rpi-sb-provisioner
2.3.1, rpiboot 20260603~182203, rpi-eeprom 28.28-1), target: Raspberry Pi 5 Model B
8GB Rev 1.1 (BCM2712 C1, boardrev d04171), naked provisioning to SD.

Same firmware (`pieeprom-2026-06-17.bin`), same bootloader config, same board:

| EEPROM write path                          | EEPROM_HASH  | Boots |
|--------------------------------------------|--------------|-------|
| Manual `rpiboot -d recovery5/` (unsigned)   | `4707d234…`  | ✅    |
| Provisioner 2.3.1 stock (signed config)     | `60bb7b48…`  | ❌    |
| Provisioner with this patch (unsigned)      | `4707d234…`  | ✅    |

With the patch, the provisioner produces a byte-identical EEPROM to the known-good
manual usbboot recovery5 flash, and the device boots. The `signing_available` else-branch
already implements the correct unsigned flow; this change routes naked provisioning
through it, matching the existing `case ${PROVISIONING_STYLE}` pattern used elsewhere
in the script.

The log already hints at the inconsistency before writing the broken EEPROM:
`Warning: SIGNED_BOOT=1 not found in ".../bootloader.naked"` followed by
`Signing bootloader config`.

## Notes

- Secure-boot and FDE flows are unaffected (condition only changes behaviour when
  `PROVISIONING_STYLE=naked`).
- Happy to provide full bootstrap logs and metadata JSONs from both the failing and
  passing runs if useful.