### PR TITLE
service: Fail usefully when the OS image or signing key is missing

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -193,6 +193,34 @@ rpi-sb-provisioner (2.3.2) unstable; urgency=medium
       collapse while hiding, taking childless root-port groups and tiers with
       them, and are unchanged when nothing is being hidden.
 
+  * Failing usefully on misconfiguration:
+    - Establish that a usable OS image is configured before engaging the
+      device. An unset GOLD_MASTER_OS_FILE previously reached losetup, which
+      retried for 25 seconds and then failed reporting a loop-device error,
+      having already recorded PROVISIONER-STARTED and taken the device
+      through bootstrap. Triage now classifies the configured image up front
+      and aborts with the actual reason; the provisioners re-check, since
+      their units can be started directly and the configuration can change
+      between triage selecting one and it running.
+    - Route to the IDP provisioner by classification rather than a bare
+      directory test. `-d` is also false for an IDP artefact whose directory
+      is merely absent -- an unmounted share, a deleted export -- so such a
+      device was silently handed to the .img provisioner and failed later
+      with an error naming loop devices rather than the missing artefact.
+      The directory is now held to the same one-descriptor rule the IDP
+      provisioner enforces in its own pre-flight, so the two cannot disagree
+      about whether an artefact is usable.
+    - Report whether a failure is permanent, via PROVISION_FAILED_PERMANENT
+      in the provision-failed hook environment. Hooks could previously only
+      see the stage a failure occurred in, and bootstrap-stage failures are
+      a mix of the transient (USB re-enumeration as the device reboots) and
+      the permanent (no signing key, no OS image). Anything filtering out
+      the former to avoid false alarms necessarily discarded the latter too,
+      so a jig could sit on its in-progress indicator indefinitely with a
+      misconfiguration that would never resolve. The stage is unchanged --
+      it still selects the hook's positional arguments -- so existing hooks
+      keep working and can adopt the flag when they choose.
+
   * Service lifecycle:
     - Explicitly handle device event loop termination.
 

--- a/service/rpi-fde-provisioner.sh
+++ b/service/rpi-fde-provisioner.sh
@@ -310,6 +310,14 @@ record_state "${TARGET_DEVICE_SERIAL}" "${PROVISIONER_STARTED}" "${TARGET_USB_PA
 
 systemd-notify --ready --status="Provisioning started"
 
+# Re-check the OS image here as well as in triage: these units can be started
+# directly, and the configuration can change between triage selecting a
+# provisioner and that provisioner running.
+if ! classify_gold_master_os; then
+    mark_permanent_failure
+    die "${GOLD_MASTER_OS_ERROR}"
+fi
+
 # Run provision-started hook (e.g. LED control on programming rigs)
 run_customisation_script "fde-provisioner" "provision-started" "${FASTBOOT_DEVICE_SPECIFIER}" "${TARGET_DEVICE_SERIAL}" "${RPI_DEVICE_STORAGE_TYPE}"
 

--- a/service/rpi-idp-provisioner.sh
+++ b/service/rpi-idp-provisioner.sh
@@ -215,6 +215,14 @@ record_state "${TARGET_DEVICE_SERIAL}" "${PROVISIONER_STARTED}" "${TARGET_USB_PA
 
 systemd-notify --ready --status="Provisioning started"
 
+# Re-check the OS image here as well as in triage: these units can be started
+# directly, and the configuration can change between triage selecting a
+# provisioner and that provisioner running.
+if ! classify_gold_master_os; then
+    mark_permanent_failure
+    die "${GOLD_MASTER_OS_ERROR}"
+fi
+
 ### Resolve the IDP artefact directory
 
 if [ -d "${GOLD_MASTER_OS_FILE}" ]; then

--- a/service/rpi-naked-provisioner.sh
+++ b/service/rpi-naked-provisioner.sh
@@ -223,6 +223,14 @@ fi
 
 systemd-notify --ready --status="Provisioning started"
 
+# Re-check the OS image here as well as in triage: these units can be started
+# directly, and the configuration can change between triage selecting a
+# provisioner and that provisioner running.
+if ! classify_gold_master_os; then
+    mark_permanent_failure
+    die "${GOLD_MASTER_OS_ERROR}"
+fi
+
 announce_start "Writing OS images"
 
 # Determine which image to flash. If bootfs-mounted or rootfs-mounted customisation

--- a/service/rpi-sb-bootstrap.sh
+++ b/service/rpi-sb-bootstrap.sh
@@ -656,6 +656,7 @@ if [ "$ALLOW_SIGNED_BOOT" -eq 1 ]; then
                 if [ "${TARGET_DEVICE_FAMILY}" = "2712" ]; then
                     if ! signing_available; then
                         record_state "${TARGET_DEVICE_SERIAL}" "${BOOTSTRAP_ABORTED}" "${TARGET_USB_PATH}"
+                        mark_permanent_failure
                         die "No signing key configured for re-provisioning. Aborting."
                     fi
                     log "Re-signing bootcode for special re-provisioning case"

--- a/service/rpi-sb-common.sh
+++ b/service/rpi-sb-common.sh
@@ -490,6 +490,93 @@ maybe_reorder_boot_order_for_storage() {
 # Run the provision-failed hook for programming-rig signalling (e.g. LEDs).
 # HOOK_CONTEXT is "bootstrap" (serial/family/usb/device path args) or
 # "provisioning" (fastboot specifier/serial/storage args).
+# Mark the failure in progress as a permanent misconfiguration -- something
+# retrying the same device will never resolve, such as no OS image or no
+# signing key being configured. Distinct from the stage the failure happened
+# in, which run_provision_failed_hook already reports: a bootstrap-stage
+# failure may be either transient (USB re-enumeration churn as the device
+# reboots) or permanent, and hooks that want to react loudly to the latter
+# cannot tell them apart from the stage alone.
+mark_permanent_failure() {
+    PROVISION_FAILURE_PERMANENT=1
+    export PROVISION_FAILURE_PERMANENT
+}
+
+# Classify the configured OS image, failing early when it cannot be used.
+#
+# GOLD_MASTER_OS_FILE names either a regular file (a whole-disk .img) or a
+# directory (an rpi-image-gen IDP artefact). Telling "not configured",
+# "configured but absent" and "present but unusable" apart matters because
+# triage picks the provisioner from the *shape* of this path: an IDP artefact
+# whose directory is momentarily missing -- an unmounted share, say -- is
+# otherwise indistinguishable from a .img, and gets routed to a provisioner
+# that cannot read it and fails much later with an unrelated error.
+#
+# Results come back in globals, deliberately, and nothing is written to
+# stdout: capturing a reason with $( ) would run this in a subshell and throw
+# GOLD_MASTER_OS_KIND away with it. Call it directly:
+#
+#     if ! classify_gold_master_os; then
+#         die "${GOLD_MASTER_OS_ERROR}"
+#     fi
+#
+# Sets and exports GOLD_MASTER_OS_KIND to "image" or "idp" on success, so
+# callers -- and the customisation hooks they run -- can branch on the form of
+# the artefact without re-testing the path. Sets GOLD_MASTER_OS_ERROR to the
+# reason on failure.
+# Exit:   0 when usable, 1 otherwise.
+classify_gold_master_os() {
+    GOLD_MASTER_OS_KIND=""
+    GOLD_MASTER_OS_ERROR=""
+    export GOLD_MASTER_OS_KIND GOLD_MASTER_OS_ERROR
+
+    if [ -z "${GOLD_MASTER_OS_FILE}" ]; then
+        GOLD_MASTER_OS_ERROR="No OS image is configured. Set GOLD_MASTER_OS_FILE in /etc/rpi-sb-provisioner/config, or select an image in the web UI."
+        return 1
+    fi
+
+    if [ -d "${GOLD_MASTER_OS_FILE}" ]; then
+        # IDP artefact. Apply the same descriptor rule the IDP provisioner
+        # enforces in its own pre-flight, so the two cannot disagree about
+        # whether a directory is a usable artefact.
+        _cgm_json_count=$(find "${GOLD_MASTER_OS_FILE}" -maxdepth 1 -name '*.json' -type f 2>/dev/null | wc -l)
+        if [ "${_cgm_json_count}" -eq 0 ]; then
+            GOLD_MASTER_OS_ERROR="GOLD_MASTER_OS_FILE is a directory with no JSON description file: ${GOLD_MASTER_OS_FILE}. An IDP artefact directory must contain exactly one."
+            return 1
+        fi
+        if [ "${_cgm_json_count}" -gt 1 ]; then
+            GOLD_MASTER_OS_ERROR="GOLD_MASTER_OS_FILE is a directory with ${_cgm_json_count} JSON description files: ${GOLD_MASTER_OS_FILE}. An IDP artefact directory must contain exactly one."
+            return 1
+        fi
+        GOLD_MASTER_OS_KIND="idp"
+        return 0
+    fi
+
+    if [ -f "${GOLD_MASTER_OS_FILE}" ]; then
+        if [ ! -s "${GOLD_MASTER_OS_FILE}" ]; then
+            GOLD_MASTER_OS_ERROR="Configured OS image is empty: ${GOLD_MASTER_OS_FILE}"
+            return 1
+        fi
+        if [ ! -r "${GOLD_MASTER_OS_FILE}" ]; then
+            GOLD_MASTER_OS_ERROR="Configured OS image is not readable: ${GOLD_MASTER_OS_FILE}"
+            return 1
+        fi
+        GOLD_MASTER_OS_KIND="image"
+        return 0
+    fi
+
+    if [ -e "${GOLD_MASTER_OS_FILE}" ]; then
+        GOLD_MASTER_OS_ERROR="Configured OS image is neither a regular file nor a directory: ${GOLD_MASTER_OS_FILE}"
+        return 1
+    fi
+
+    # Absent entirely. Deliberately does not guess whether a .img or an IDP
+    # directory was intended -- the path is gone, so the shape is unknowable,
+    # and a mount that has not come back is the common cause.
+    GOLD_MASTER_OS_ERROR="Configured OS image does not exist: ${GOLD_MASTER_OS_FILE}. If this is an IDP artefact directory on a removable or network mount, check the mount is present."
+    return 1
+}
+
 run_provision_failed_hook() {
     PROVISIONER_NAME="$1"
     HOOK_CONTEXT="${2:-provisioning}"
@@ -500,6 +587,10 @@ run_provision_failed_hook() {
     fi
 
     set +e
+    # Reported alongside the stage rather than folded into it: the stage still
+    # selects the hook's positional arguments, so widening it would change the
+    # contract every existing hook is written against.
+    export PROVISION_FAILED_PERMANENT="${PROVISION_FAILURE_PERMANENT:-0}"
     if [ "${HOOK_CONTEXT}" = "bootstrap" ]; then
         export PROVISION_FAILED_CONTEXT=bootstrap
         run_customisation_script "${PROVISIONER_NAME}" "provision-failed" \
@@ -512,6 +603,7 @@ run_provision_failed_hook() {
             "${RPI_DEVICE_STORAGE_TYPE}"
     fi
     unset PROVISION_FAILED_CONTEXT
+    unset PROVISION_FAILED_PERMANENT
 }
 
 run_customisation_script() {
@@ -815,6 +907,7 @@ get_openssl_sign_args() {
         *)
             # NB: pem-wrapped has no openssl directive form (the key is never on
             # disk). Such callers must use sign_image_hex(), not this function.
+            mark_permanent_failure
             log "ERROR: No signing key configured (get_openssl_sign_args)"
             return 1
             ;;
@@ -954,6 +1047,7 @@ get_sign_bootcode_key_args() {
             echo "-k ${CUSTOMER_KEY_FILE_PEM}"
             ;;
         *)
+            mark_permanent_failure
             log "ERROR: No signing key configured (bootcode signing requires a key)"
             return 1
             ;;

--- a/service/rpi-sb-provisioner.sh
+++ b/service/rpi-sb-provisioner.sh
@@ -345,6 +345,14 @@ record_state "${TARGET_DEVICE_SERIAL}" "${PROVISIONER_STARTED}" "${TARGET_USB_PA
 
 systemd-notify --ready --status="Provisioning started"
 
+# Re-check the OS image here as well as in triage: these units can be started
+# directly, and the configuration can change between triage selecting a
+# provisioner and that provisioner running.
+if ! classify_gold_master_os; then
+    mark_permanent_failure
+    die "${GOLD_MASTER_OS_ERROR}"
+fi
+
 # Run provision-started hook (e.g. LED control on programming rigs)
 run_customisation_script "sb-provisioner" "provision-started" "${FASTBOOT_DEVICE_SPECIFIER}" "${TARGET_DEVICE_SERIAL}" "${RPI_DEVICE_STORAGE_TYPE}"
 

--- a/service/rpi-sb-triage.sh
+++ b/service/rpi-sb-triage.sh
@@ -184,6 +184,19 @@ fi
 # Record state changes atomically
 record_state "${TARGET_DEVICE_SERIAL}" "${TRIAGE_STARTED}" "${TARGET_USB_PATH}"
 
+# Establish that there is a usable OS image before engaging the device. This
+# is a misconfiguration that no amount of retrying will resolve, so say so
+# plainly here rather than letting a provisioner discover it much later --
+# previously an unset GOLD_MASTER_OS_FILE got all the way to losetup, which
+# retried for 25 seconds before failing with an error about loop devices.
+if ! classify_gold_master_os; then
+    mark_permanent_failure
+    log "${GOLD_MASTER_OS_ERROR}"
+    record_state "${TARGET_DEVICE_SERIAL}" "${TRIAGE_ABORTED}" "${TARGET_USB_PATH}"
+    die "${GOLD_MASTER_OS_ERROR}"
+fi
+log "OS image: ${GOLD_MASTER_OS_FILE} (${GOLD_MASTER_OS_KIND})"
+
 if [ -d "/var/log/rpi-sb-provisioner/${TARGET_DEVICE_SERIAL32}" ]; then
     cp -rf "/var/log/rpi-sb-provisioner/${TARGET_DEVICE_SERIAL32}/." "${LOG_DIRECTORY}/"
     rm -rf "/var/log/rpi-sb-provisioner/${TARGET_DEVICE_SERIAL32}"
@@ -245,12 +258,16 @@ echo "${TRIAGE_STARTED}" >> "${LOG_DIRECTORY}"/triage.log
 # timestamp as PROVISIONER-STARTED but sort after it -- the state race seen in
 # the UI.  Triage's job is done once it has selected the provisioner, so record
 # TRIAGE-FINISHED first and hand off last.
-if [ -d "${GOLD_MASTER_OS_FILE}" ]; then
-    # GOLD_MASTER_OS_FILE is a directory -- this is an IDP artefact.
+# Routing keys off the classification above rather than a bare `-d` test. The
+# two are not equivalent: `-d` is also false for an IDP artefact whose
+# directory is simply absent -- an unmounted share, a deleted export -- which
+# silently routed such a device to the .img provisioner, where it failed later
+# with an error naming loop devices rather than the missing artefact.
+if [ "${GOLD_MASTER_OS_KIND}" = "idp" ]; then
     # Route to the IDP provisioner regardless of PROVISIONING_STYLE,
     # since the IDP provisioner handles the image format natively.
     # (Secure boot is handled by the bootstrap phase, not the provisioner.)
-    log "GOLD_MASTER_OS_FILE is a directory; selecting IDP Provisioner"
+    log "GOLD_MASTER_OS_FILE is an IDP artefact directory; selecting IDP Provisioner"
     TARGET_PROVISIONER_UNIT="rpi-idp-provisioner@${TARGET_DEVICE_SERIAL}.service"
 else
     # Traditional .img file -- use the PROVISIONING_STYLE switch as before
@@ -268,7 +285,9 @@ else
             TARGET_PROVISIONER_UNIT="rpi-naked-provisioner@${TARGET_DEVICE_SERIAL}.service"
         ;;
         *)
+            mark_permanent_failure
             log "Fatal: Unknown provisioning style: ${PROVISIONING_STYLE}"
+            record_state "${TARGET_DEVICE_SERIAL}" "${TRIAGE_ABORTED}" "${TARGET_USB_PATH}"
             exit 1
         ;;
     esac


### PR DESCRIPTION
Three related gaps, all of which turned a misconfiguration into a confusing late failure or none at all.

An unset GOLD_MASTER_OS_FILE was never checked. Triage tested only whether the path was a directory, so an empty value fell through to the PROVISIONING_STYLE switch and started a provisioner, which recorded PROVISIONER-STARTED, engaged the device, and eventually reached

    until ensure_next_loopdev && LOOP_DEV="$(losetup ... "${GOLD_MASTER_OS_FILE}")"

where it retried five times at five-second intervals before dying with "losetup failed after 5 retries". Twenty-five seconds to report a loop-device error for a station that simply has no image selected.

Add classify_gold_master_os() to the common library, distinguishing not configured, absent, present-but-unusable, .img and IDP artefact, and call it in triage before the device is touched. The provisioners re-check: their units can be started directly, and the configuration can change between triage selecting one and it running.

That also fixes IDP routing. `-d` is false both for a .img and for an IDP artefact whose directory is merely absent -- an unmounted share, a deleted export -- so the latter was silently routed to the .img provisioner and failed later with an error about loop devices rather than the missing artefact. Routing now keys off the classification, which holds the directory to the same one-descriptor rule the IDP provisioner applies in its own pre-flight so the two cannot disagree.

Finally, report permanence to the provision-failed hook. Hooks could only see the stage, and bootstrap-stage failures mix the transient (USB re-enumeration while the device reboots) with the permanent (no signing key, no OS image). Any hook filtering the former to avoid false alarms discarded the latter with it -- the CM5 jig does exactly this, so a station with no signing key configured sits on its blue in-progress LED indefinitely, the provision-failed hook having fired and returned without acting.

PROVISION_FAILED_PERMANENT is exported alongside the existing context rather than folded into it, because the context selects the hook's positional arguments and widening it would change the contract every existing hook is written against.

The classifier returns its results in globals and writes nothing to stdout: reading a reason with $( ) would run it in a subshell and discard the classification with it.